### PR TITLE
fix : "이미지 테스트 완료후 각 도메인별 service 메서드 생성"

### DIFF
--- a/src/main/java/PNUMEAT/Backend/global/images/Image.java
+++ b/src/main/java/PNUMEAT/Backend/global/images/Image.java
@@ -40,17 +40,20 @@ public class Image {
         return "";
     }
 
-    public String uploadToS3(S3Client s3Client, String bucket, String region) {
+    public String uploadToS3(S3Client s3Client, String bucket, String region, String folder) {
+        String s3Key = folder + "/" + this.uniqueFileName;
+
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
             .bucket(bucket)
-            .key(this.uniqueFileName)
+            .key(s3Key)
             .acl(ObjectCannedACL.PUBLIC_READ)
             .build();
 
         s3Client.putObject(putObjectRequest, RequestBody.fromFile(this.localFile));
 
-        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, this.uniqueFileName);
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, s3Key);
     }
+
 
     public boolean deleteLocalFile() {
         return localFile.delete();

--- a/src/main/java/PNUMEAT/Backend/global/images/ImageService.java
+++ b/src/main/java/PNUMEAT/Backend/global/images/ImageService.java
@@ -16,17 +16,19 @@ public class ImageService {
     private final AwsProperties awsProperties;
 
     private static final String LOCAL_LOCATION = "/Users/pakjeongwoo/Downloads/";
+    private static final String PROFILE_FOLDER = "profile";
+    private static final String TEAM_FOLDER = "team";
     public ImageService(S3Client s3Client, AwsProperties awsProperties) {
         this.s3Client = s3Client;
         this.awsProperties = awsProperties;
     }
 
-    public String imageUpload(MultipartFile multipartFile) {
+    public String profileImageUpload(MultipartFile multipartFile) {
         String s3Url;
         try {
             String uuid = UUID.randomUUID().toString();
             Image image = new Image(multipartFile, uuid, LOCAL_LOCATION);
-            s3Url = image.uploadToS3(s3Client, awsProperties.getBucket(), awsProperties.getRegion());
+            s3Url = image.uploadToS3(s3Client, awsProperties.getBucket(), awsProperties.getRegion(),PROFILE_FOLDER);
 
             if (!image.deleteLocalFile()) {
                 log.error("로컬 파일 삭제 실패: {}", image.getLocalPath());
@@ -39,12 +41,48 @@ public class ImageService {
         return s3Url;
     }
 
-    public String imageUpdate(MultipartFile multipartFile, String imageUrl) {
+    public String profileImageUpdate(MultipartFile multipartFile, String imageUrl) {
         String updatedS3Url;
         try {
             String key = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
             Image image = new Image(multipartFile, key, LOCAL_LOCATION);
-            updatedS3Url = image.uploadToS3(s3Client, awsProperties.getBucket(), awsProperties.getRegion());
+            updatedS3Url = image.uploadToS3(s3Client, awsProperties.getBucket(), awsProperties.getRegion(),PROFILE_FOLDER);
+
+            if (!image.deleteLocalFile()) {
+                log.error("로컬 파일 삭제 실패: {}", image.getLocalPath());
+            }
+        } catch (Exception e) {
+            log.error("이미지 업데이트 중 오류 발생: {}", e.getMessage());
+            throw new ImageFileUploadException();
+        }
+
+        return updatedS3Url;
+    }
+
+    public String teamImageUpload(MultipartFile multipartFile) {
+        String s3Url;
+        try {
+            String uuid = UUID.randomUUID().toString();
+            Image image = new Image(multipartFile, uuid, LOCAL_LOCATION);
+            s3Url = image.uploadToS3(s3Client, awsProperties.getBucket(), awsProperties.getRegion(),TEAM_FOLDER);
+
+            if (!image.deleteLocalFile()) {
+                log.error("로컬 파일 삭제 실패: {}", image.getLocalPath());
+            }
+        } catch (Exception e) {
+            log.error("파일 처리 중 오류 발생: {}", e.getMessage());
+            throw new ImageFileUploadException();
+        }
+
+        return s3Url;
+    }
+
+    public String teamImageUpdate(MultipartFile multipartFile, String imageUrl) {
+        String updatedS3Url;
+        try {
+            String key = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+            Image image = new Image(multipartFile, key, LOCAL_LOCATION);
+            updatedS3Url = image.uploadToS3(s3Client, awsProperties.getBucket(), awsProperties.getRegion(),TEAM_FOLDER);
 
             if (!image.deleteLocalFile()) {
                 log.error("로컬 파일 삭제 실패: {}", image.getLocalPath());


### PR DESCRIPTION
Resolves #{이슈-번호}

# ❓ 해결하려는 문제가 무엇인가요?

각각 도메인별 메서드를 분리하자 
UUID를 이미지 로직에서 만들어서 저장하자
각 도메인별로 다른 폴더에 이미지를 저장하자 

# 🛠️ 어떻게 해결했나요?

메서드 분리후 생성
UUID 로직 추가
폴더 생성후 테스트 완료

# 🔍 어떤 부분에 집중하여 리뷰해야 할까요?

리팩토링 해야할부분이 뭔지

## 📚 참고 자료

.

---

# 📋 RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
