### PR TITLE
[스프린트 3] 강수민 - 팀 생성 기능 추가 

### DIFF
--- a/src/main/java/PNUMEAT/Backend/domain/auth/entity/Member.java
+++ b/src/main/java/PNUMEAT/Backend/domain/auth/entity/Member.java
@@ -4,6 +4,7 @@ package PNUMEAT.Backend.domain.auth.entity;
 import static PNUMEAT.Backend.global.images.ImageConstant.DEFAULT_MEMBER_PROFILE_IMAGE_URL;
 
 import PNUMEAT.Backend.domain.article.entity.Article;
+import PNUMEAT.Backend.domain.team_member.entity.TeamMember;
 import jakarta.persistence.*;
 
 import java.util.ArrayList;
@@ -39,6 +40,9 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private List<Article> articles = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<TeamMember> teamMembers = new ArrayList<>();
 
     protected Member() {
     }

--- a/src/main/java/PNUMEAT/Backend/domain/team/controller/TeamController.java
+++ b/src/main/java/PNUMEAT/Backend/domain/team/controller/TeamController.java
@@ -1,0 +1,40 @@
+package PNUMEAT.Backend.domain.team.controller;
+
+import PNUMEAT.Backend.domain.auth.dto.request.MemberProfileRequest;
+import PNUMEAT.Backend.domain.auth.entity.Member;
+import PNUMEAT.Backend.domain.auth.service.MemberService;
+import PNUMEAT.Backend.domain.team.dto.request.TeamRequest;
+import PNUMEAT.Backend.domain.team.service.TeamService;
+import PNUMEAT.Backend.global.error.dto.response.ApiResponse;
+import PNUMEAT.Backend.global.security.annotation.LoginMember;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import static PNUMEAT.Backend.global.response.ResponseMessageEnum.TEAM_CREATED_SUCCESS;
+
+@RestController
+@RequestMapping("/api/v1/teams")
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamService teamService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> createTeam(@ModelAttribute @Valid TeamRequest teamRequest,
+                                                              @RequestPart(value = "teamIcon", required = false) MultipartFile teamIcon,
+                                                              @LoginMember Member member){
+        teamService.createTeam(teamRequest, teamIcon, member);
+
+        return ResponseEntity.status(TEAM_CREATED_SUCCESS.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.createResponseWithMessage(TEAM_CREATED_SUCCESS.getMessage()));
+    }
+}
+
+

--- a/src/main/java/PNUMEAT/Backend/domain/team/dto/request/TeamRequest.java
+++ b/src/main/java/PNUMEAT/Backend/domain/team/dto/request/TeamRequest.java
@@ -1,0 +1,43 @@
+package PNUMEAT.Backend.domain.team.dto.request;
+
+import PNUMEAT.Backend.global.validation.annotation.NotNullOrBlank;
+import jakarta.validation.constraints.*;
+
+public record TeamRequest(
+        @NotNullOrBlank
+        @Pattern(
+                regexp = "^[가-힣a-zA-Z0-9\\s]*$",
+                message = "한글, 영어, 숫자, 공백만 입력 가능합니다."
+        )
+        @Size(
+                max = 10,
+                message = "글자 수를 초과했습니다."
+        )
+        String teamName,
+
+        @Pattern(
+                regexp = "^[가-힣a-zA-Z0-9!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?`~ ]*$",
+                message = "팀 설명은 한글, 영어, 숫자, 기본 특수문자만 사용가능합니다."
+        )
+        @Size(
+                max = 50,
+                message = "글자 수를 초과했습니다."
+        )
+        String teamExplain,
+
+        @NotNullOrBlank
+        String topic,
+
+        @NotNullOrBlank
+        @Digits(integer = Integer.MAX_VALUE, fraction = 0, message = "2 ~ 20 사이의 숫자를 입력해주세요.")
+        @Min(value = 2, message = "2 ~ 20 사이의 숫자를 입력해주세요.")
+        @Max(value = 20, message = "2 ~ 20 사이의 숫자를 입력해주세요.")
+        int memberLimit,
+
+        @Pattern(
+                regexp = "^[0-9]{4}$",
+                message = "숫자 4자리를 입력해주세요."
+        )
+        String password
+) {
+}

--- a/src/main/java/PNUMEAT/Backend/domain/team/entity/Team.java
+++ b/src/main/java/PNUMEAT/Backend/domain/team/entity/Team.java
@@ -1,0 +1,66 @@
+package PNUMEAT.Backend.domain.team.entity;
+
+import PNUMEAT.Backend.domain.auth.entity.Member;
+import PNUMEAT.Backend.domain.team.enums.Topic;
+import PNUMEAT.Backend.domain.team_member.entity.TeamMember;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static PNUMEAT.Backend.global.images.ImageConstant.DEFAULT_TEAM_IMAGE_URL;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class Team {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long teamId;
+
+    private String teamName;
+
+    private String teamIconUrl = DEFAULT_TEAM_IMAGE_URL;
+
+    private Topic teamTopic;
+
+    private String teamExplain;
+
+    private int maxParticipant;
+
+    private String teamPassword;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    private int streakDays;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member teamManager;
+
+    @OneToMany(mappedBy = "team")
+    private List<TeamMember> teamMembers = new ArrayList<>();
+
+    protected Team(){
+    }
+
+    @Builder
+    public Team(String teamName, Topic teamTopic, String teamExplain, int maxParticipant, String teamPassword, Member teamManager) {
+        this.teamName = teamName;
+        this.teamTopic = teamTopic;
+        this.teamExplain = teamExplain;
+        this.maxParticipant = maxParticipant;
+        this.teamPassword = teamPassword;
+        this.teamManager = teamManager;
+    }
+
+    public void updateTeamIconUrl(String teamIconUrl){
+        this.teamIconUrl = teamIconUrl;
+    }
+}

--- a/src/main/java/PNUMEAT/Backend/domain/team/enums/Topic.java
+++ b/src/main/java/PNUMEAT/Backend/domain/team/enums/Topic.java
@@ -1,0 +1,36 @@
+package PNUMEAT.Backend.domain.team.enums;
+
+import PNUMEAT.Backend.global.error.ErrorCode;
+import PNUMEAT.Backend.global.error.Team24Exception;
+
+import static PNUMEAT.Backend.global.error.ErrorCode.TOPIC_INVALID_ERROR;
+
+public enum Topic {
+    CODINGTEST(1, "코딩테스트"),
+    STUDY(2, "스터디");
+
+    private final int code;
+    private final String name;
+
+    Topic(int code, String name) {
+        this.code = code;
+        this.name = name;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static Topic fromName(String name){
+        for(Topic topic : Topic.values()){
+            if(topic.getName().equals(name)){
+                return topic;
+            }
+        }
+        throw new Team24Exception(TOPIC_INVALID_ERROR);
+    }
+}

--- a/src/main/java/PNUMEAT/Backend/domain/team/repository/TeamRepository.java
+++ b/src/main/java/PNUMEAT/Backend/domain/team/repository/TeamRepository.java
@@ -1,0 +1,7 @@
+package PNUMEAT.Backend.domain.team.repository;
+
+import PNUMEAT.Backend.domain.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/src/main/java/PNUMEAT/Backend/domain/team/service/TeamService.java
+++ b/src/main/java/PNUMEAT/Backend/domain/team/service/TeamService.java
@@ -1,0 +1,49 @@
+package PNUMEAT.Backend.domain.team.service;
+
+import PNUMEAT.Backend.domain.auth.entity.Member;
+import PNUMEAT.Backend.domain.team.dto.request.TeamRequest;
+import PNUMEAT.Backend.domain.team.entity.Team;
+import PNUMEAT.Backend.domain.team.enums.Topic;
+import PNUMEAT.Backend.domain.team.repository.TeamRepository;
+import PNUMEAT.Backend.domain.team_member.entity.TeamMember;
+import PNUMEAT.Backend.domain.team_member.repository.TeamMemberRepository;
+import PNUMEAT.Backend.global.images.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamService {
+
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final ImageService imageService;
+
+    @Transactional
+    public Team createTeam(TeamRequest teamRequest,
+                           MultipartFile teamIcon, Member member){
+
+        Team team = Team.builder()
+                .teamName(teamRequest.teamName())
+                .teamExplain(teamRequest.teamExplain())
+                .teamTopic(Topic.fromName(teamRequest.topic()))
+                .maxParticipant(teamRequest.memberLimit())
+                .teamPassword(teamRequest.password())
+                .teamManager(member)
+                .build();
+
+        if (teamIcon != null){
+            String teamIconUrl = imageService.teamImageUpload(teamIcon);
+            team.updateTeamIconUrl(teamIconUrl);
+        }
+
+        TeamMember teamMember = new TeamMember(team, member);
+
+        teamMemberRepository.save(teamMember);
+
+        return teamRepository.save(team);
+    }
+}

--- a/src/main/java/PNUMEAT/Backend/domain/team_member/entity/TeamMember.java
+++ b/src/main/java/PNUMEAT/Backend/domain/team_member/entity/TeamMember.java
@@ -1,0 +1,42 @@
+package PNUMEAT.Backend.domain.team_member.entity;
+
+import PNUMEAT.Backend.domain.auth.entity.Member;
+import PNUMEAT.Backend.domain.team.entity.Team;
+import jakarta.persistence.*;
+
+import java.util.Objects;
+
+@Entity
+public class TeamMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long teamInfoId;
+
+    @ManyToOne
+    @JoinColumn(name="member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name="team_id")
+    private Team team;
+
+    protected TeamMember(){}
+
+    public TeamMember(Team team, Member member) {
+        this.member = member;
+        this.team = team;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TeamMember that = (TeamMember) o;
+        return Objects.equals(teamInfoId, that.teamInfoId) && Objects.equals(member, that.member) && Objects.equals(team, that.team);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(teamInfoId, member, team);
+    }
+}

--- a/src/main/java/PNUMEAT/Backend/domain/team_member/repository/TeamMemberRepository.java
+++ b/src/main/java/PNUMEAT/Backend/domain/team_member/repository/TeamMemberRepository.java
@@ -1,0 +1,9 @@
+package PNUMEAT.Backend.domain.team_member.repository;
+
+import PNUMEAT.Backend.domain.team_member.entity.TeamMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+}

--- a/src/main/java/PNUMEAT/Backend/global/error/ErrorCode.java
+++ b/src/main/java/PNUMEAT/Backend/global/error/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
 
     ARTICLE_FORBIDDEN_ERROR(HttpStatus.FORBIDDEN, "게시글 권한이 없습니다."),
 
+    //TEAM
+    TOPIC_INVALID_ERROR(HttpStatus.BAD_REQUEST, "주제가 올바른 형식이 아닙니다."),
+
     // ARTICLE
     ARTICLE_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "존재 하지 않는 게시글 입니다."),
 

--- a/src/main/java/PNUMEAT/Backend/global/response/ResponseMessageEnum.java
+++ b/src/main/java/PNUMEAT/Backend/global/response/ResponseMessageEnum.java
@@ -1,0 +1,18 @@
+package PNUMEAT.Backend.global.response;
+
+import lombok.Getter;
+
+@Getter
+public enum ResponseMessageEnum {
+    // TEAM
+    TEAM_CREATED_SUCCESS("팀이 성공적으로 생성되었습니다.", 201);
+
+
+    private final String message;
+    private final int statusCode;
+
+    ResponseMessageEnum(String message, int statusCode) {
+        this.message = message;
+        this.statusCode = statusCode;
+    }
+}

--- a/src/main/java/PNUMEAT/Backend/global/validation/annotation/NotNullOrBlank.java
+++ b/src/main/java/PNUMEAT/Backend/global/validation/annotation/NotNullOrBlank.java
@@ -1,0 +1,19 @@
+package PNUMEAT.Backend.global.validation.annotation;
+
+import PNUMEAT.Backend.global.validation.validator.NotNullOrBlankValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = NotNullOrBlankValidator.class)
+public @interface NotNullOrBlank {
+    String message() default "값은 null이거나 공백만 입력될 수 없습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/PNUMEAT/Backend/global/validation/validator/NotNullOrBlankValidator.java
+++ b/src/main/java/PNUMEAT/Backend/global/validation/validator/NotNullOrBlankValidator.java
@@ -1,0 +1,12 @@
+package PNUMEAT.Backend.global.validation.validator;
+
+import PNUMEAT.Backend.global.validation.annotation.NotNullOrBlank;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NotNullOrBlankValidator implements ConstraintValidator<NotNullOrBlank, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/src/test/java/PNUMEAT/Backend/domain/team/service/TeamServiceTest.java
+++ b/src/test/java/PNUMEAT/Backend/domain/team/service/TeamServiceTest.java
@@ -1,0 +1,122 @@
+package PNUMEAT.Backend.domain.team.service;
+
+import PNUMEAT.Backend.domain.auth.entity.Member;
+import PNUMEAT.Backend.domain.team.dto.request.TeamRequest;
+import PNUMEAT.Backend.domain.team.entity.Team;
+import PNUMEAT.Backend.domain.team.enums.Topic;
+import PNUMEAT.Backend.domain.team.repository.TeamRepository;
+import PNUMEAT.Backend.domain.team_member.entity.TeamMember;
+import PNUMEAT.Backend.domain.team_member.repository.TeamMemberRepository;
+import PNUMEAT.Backend.global.images.ImageConstant;
+import PNUMEAT.Backend.global.images.ImageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private TeamRepository teamRepository; // teamRepository를 모킹
+
+    @Mock
+    private TeamMemberRepository teamMemberRepository; // TeamMemberRepository도 모킹
+
+    @InjectMocks
+    private TeamService teamService;
+
+    @Test
+    @DisplayName("팀 등록 시 teamIcon을 등록하지 않았다면 기본 이미지가 등록된다.")
+    void 팀_등록_시_기본_이미지_등록_테스트() {
+        //given
+        TeamRequest teamRequest = new TeamRequest(
+                "한글Team1",
+                "이 팀은 예시 팀입니다!",
+                "스터디",
+                10,
+                "1234"
+        );
+        Member member = new Member("TEST", "TEST", "ROLE_USER");
+        MultipartFile teamIcon = null;
+
+        Team team = Team.builder()
+                .teamName(teamRequest.teamName())
+                .teamExplain(teamRequest.teamExplain())
+                .teamTopic(Topic.fromName(teamRequest.topic()))
+                .maxParticipant(teamRequest.memberLimit())
+                .teamPassword(teamRequest.password())
+                .teamManager(member)
+                .build();
+
+        given(teamRepository.save(any(Team.class))).willReturn(team);
+
+        TeamMember teamMember = new TeamMember(team, member);
+        given(teamMemberRepository.save(any(TeamMember.class))).willReturn(teamMember);
+
+        //when
+        Team createdTeam = teamService.createTeam(teamRequest, teamIcon, member);
+
+        //then
+        assertThat(createdTeam.getTeamIconUrl()).isEqualTo(ImageConstant.DEFAULT_TEAM_IMAGE_URL);
+        assertThat(createdTeam.getTeamName()).isEqualTo(teamRequest.teamName());
+        assertThat(createdTeam.getTeamManager().getMemberName()).isEqualTo(member.getMemberName());
+    }
+
+    @Test
+    @DisplayName("회원 프로필 등록 시 image를 등록하면 imageUrl이 변경된다.")
+    void 프로필_등록_시_이미지_등록_테스트() {
+        //given
+        TeamRequest teamRequest = new TeamRequest(
+                "한글Team1",
+                "이 팀은 예시 팀입니다!",
+                "스터디",
+                10,
+                "1234"
+        );
+
+        MultipartFile teamIcon = new MockMultipartFile("TEST",
+                "TEST.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "TEST".getBytes());
+
+        Member member = new Member("TEST", "TEST", "ROLE_USER");
+
+        Team team = Team.builder()
+                .teamName(teamRequest.teamName())
+                .teamExplain(teamRequest.teamExplain())
+                .teamTopic(Topic.fromName(teamRequest.topic()))
+                .maxParticipant(teamRequest.memberLimit())
+                .teamPassword(teamRequest.password())
+                .teamManager(member)
+                .build();
+        team.updateTeamIconUrl("s3://");
+
+        given(imageService.teamImageUpload(teamIcon)).willReturn("s3://");
+
+        given(teamRepository.save(any(Team.class))).willReturn(team);
+
+        TeamMember teamMember = new TeamMember(team, member);
+        given(teamMemberRepository.save(any(TeamMember.class))).willReturn(teamMember);
+
+        //when
+        Team createdTeam = teamService.createTeam(teamRequest, teamIcon, member);
+
+        //then
+        assertThat(createdTeam.getTeamIconUrl()).isEqualTo("s3://");
+        assertThat(createdTeam.getTeamName()).isEqualTo(teamRequest.teamName());
+        assertThat(createdTeam.getTeamManager().getMemberName()).isEqualTo(member.getMemberName());
+    }
+}


### PR DESCRIPTION
Resolves #21 

# ❓ 해결하려는 문제가 무엇인가요?

- 팀 생성 기능을 만든다.

# 🛠️ 어떻게 해결했나요?

- Valid 어노테이션을 사용하여 입력값을 검증했다.
- TeamMember 테이블을 만들어 다대다 관계를 만들었다.
- 팀 생성자를 일단 팀 매니저로 임명했다. 한 명의 회원이 여러 팀의 회장일 수 있으므로, 일대다 관계로 설정했으며, 단방향으로 설정하였다.

# 🔍 어떤 부분에 집중하여 리뷰해야 할까요?

- TeamRequest Dto 코드가 난잡해서 리팩토링이 필요할 것 같다.
- 마찬가지로 TeamService의 createTeam도 함수길이가 길어 메서드 분리가 필요할 것 같아서 체크하면 좋을 것 같다.

## 📚 참고 자료

-

---

# 📋 RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
