### PR TITLE
[스프린트 5] 강수민 - 팀 주제 생성 및 조회 기능 테스트 작성

### DIFF
--- a/src/main/java/PNUMEAT/Backend/domain/article/dto/response/TeamSubjectResponse.java
+++ b/src/main/java/PNUMEAT/Backend/domain/article/dto/response/TeamSubjectResponse.java
@@ -1,6 +1,7 @@
 package PNUMEAT.Backend.domain.article.dto.response;
 
 import PNUMEAT.Backend.domain.article.entity.Article;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
 
@@ -9,6 +10,7 @@ public record TeamSubjectResponse(
         String articleCategory,
         String articleTitle,
         String articleBody,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdDate,
         String imageUrl
 ) {

--- a/src/test/java/PNUMEAT/Backend/domain/article/repository/ArticleRepositoryTest.java
+++ b/src/test/java/PNUMEAT/Backend/domain/article/repository/ArticleRepositoryTest.java
@@ -9,8 +9,6 @@ import PNUMEAT.Backend.domain.team.entity.Team;
 import PNUMEAT.Backend.domain.team.enums.Topic;
 import PNUMEAT.Backend.domain.team.repository.TeamRepository;
 import jakarta.persistence.EntityManager;
-import java.time.Month;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static PNUMEAT.Backend.domain.article.enums.ArticleCategory.getSubjectCategories;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -46,6 +45,7 @@ class ArticleRepositoryTest {
     private Member testMember;
     private Team testTeam;
     private Article testArticle;
+    private  Article subjectArticle1;
 
     @BeforeEach
     void setup() {
@@ -62,7 +62,7 @@ class ArticleRepositoryTest {
                 new Article(testTeam, testMember, "Test Title", "Test Body", ArticleCategory.NORMAL, new ArrayList<>())
         );
 
-        Article subjectArticle1 = new Article(
+        subjectArticle1 = new Article(
                 testTeam,
                 testMember,
                 "test1",
@@ -89,7 +89,6 @@ class ArticleRepositoryTest {
                 LocalDate.parse("2024-12-13")
         );
 
-        // Add an ArticleImage to the Article
         ArticleImage testImage = new ArticleImage("http://test-image-url.com", testArticle);
         testArticle.addImage(testImage);
         articleRepository.save(testArticle);
@@ -176,5 +175,42 @@ class ArticleRepositoryTest {
         assertThat(subjectArticles.get(0).getArticleCategory()).isEqualTo(ArticleCategory.STUDY_PREVIEW);
         assertThat(subjectArticles.get(1).getArticleCategory()).isEqualTo(ArticleCategory.STUDY);
         assertThat(subjectArticles.get(2).getArticleCategory()).isEqualTo(ArticleCategory.STUDY_REVIEW);
+    }
+
+    @Test
+    @DisplayName("팀과 설정 날짜로 팀 주제 찾기 - 주제가 있는 경우")
+    void findTeamSubjectByTeamAndSelectedDate_주제가_있는_경우() {
+        // given
+        LocalDate selectedDate = LocalDate.parse("2024-12-11");
+
+        // when
+        Optional<Article> subjectArticle = articleRepository.findTeamSubjectByTeamAndSelectedDate(
+                testTeam.getTeamId(),
+                selectedDate,
+                ArticleCategory.getSubjectCategories()
+        );
+
+        // then
+        assertThat(subjectArticle.isPresent()).isEqualTo(true);
+        assertThat(subjectArticle.get().getArticleId()).isEqualTo(subjectArticle1.getArticleId());
+        assertThat(subjectArticle.get().getTeam().getTeamId()).isEqualTo(testTeam.getTeamId());
+        assertThat(subjectArticle.get().getSelectedDate()).isEqualTo(subjectArticle.get().getSelectedDate());
+    }
+
+    @Test
+    @DisplayName("팀과 설정 날짜로 팀 주제 찾기 - 주제가 없는 경우")
+    void findTeamSubjectByTeamAndSelectedDate_주제가_없는_경우() {
+        // given
+        LocalDate selectedDate = LocalDate.parse("2024-12-09");
+
+        // when
+        Optional<Article> subjectArticle = articleRepository.findTeamSubjectByTeamAndSelectedDate(
+                testTeam.getTeamId(),
+                selectedDate,
+                ArticleCategory.getSubjectCategories()
+        );
+
+        // then
+        assertThat(subjectArticle.isEmpty()).isEqualTo(true);
     }
 }

--- a/src/test/java/PNUMEAT/Backend/domain/article/service/ArticleServiceTest.java
+++ b/src/test/java/PNUMEAT/Backend/domain/article/service/ArticleServiceTest.java
@@ -1,226 +1,263 @@
 package PNUMEAT.Backend.domain.article.service;
 
-import PNUMEAT.Backend.domain.article.dto.request.ArticleRequest;
 import PNUMEAT.Backend.domain.article.dto.request.TeamSubjectRequest;
 import PNUMEAT.Backend.domain.article.entity.Article;
-import PNUMEAT.Backend.domain.article.enums.ArticleCategory;
+import PNUMEAT.Backend.domain.article.repository.ArticleImageRepository;
 import PNUMEAT.Backend.domain.article.repository.ArticleRepository;
 import PNUMEAT.Backend.domain.auth.entity.Member;
-import PNUMEAT.Backend.domain.auth.repository.MemberRepository;
 import PNUMEAT.Backend.domain.team.entity.Team;
 import PNUMEAT.Backend.domain.team.enums.Topic;
 import PNUMEAT.Backend.domain.team.repository.TeamRepository;
-import PNUMEAT.Backend.domain.teamMember.entity.TeamMember;
-import PNUMEAT.Backend.global.error.Member.MemberNotFoundException;
-import PNUMEAT.Backend.global.error.articles.UnauthorizedActionException;
+import PNUMEAT.Backend.domain.teamMember.repository.TeamMemberRepository;
+import PNUMEAT.Backend.global.error.Team.TeamManagerInvalidException;
+import PNUMEAT.Backend.global.error.Team.TeamMemberInvalidException;
+import PNUMEAT.Backend.global.error.Team.TeamNotFoundException;
+import PNUMEAT.Backend.global.error.articles.SubjectDuplicatedException;
 import PNUMEAT.Backend.global.images.ImageService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
+import static PNUMEAT.Backend.domain.article.enums.ArticleCategory.STUDY;
 import static PNUMEAT.Backend.domain.article.enums.ArticleCategory.getSubjectCategories;
+import static PNUMEAT.Backend.global.error.ErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
 
-@SpringBootTest
-@Transactional
+@ExtendWith(MockitoExtension.class)
 class ArticleServiceTest {
+    @Mock
+    private ImageService imageService;
 
-    @Autowired
-    private ArticleService articleService;
-
-    @Autowired
-    private ArticleRepository articleRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
+    @Mock
     private TeamRepository teamRepository;
 
-    @MockBean
-    private ImageService imageService;
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @Mock
+    private ArticleImageRepository articleImageRepository;
+
+    @Mock
+    private TeamMemberRepository teamMemberRepository;
+
+    @InjectMocks
+    private ArticleService articleService;
 
     private Member testMember;
     private Team testTeam;
-    private Article testArticle;
+    private Article savedArticle;
+    private MockMultipartFile mockImage;
+    private String imageUrl;
+    private String selectedDateStr;
+    private String articleCategoryStr;
+    private String articleTitle;
+    private String articleBody;
 
     @BeforeEach
     void setup() {
-        testMember = memberRepository.save(new Member("test@example.com", "testuser", "USER"));
-        testTeam = teamRepository.save(
-                new Team("Test Team", Topic.STUDY, "This is a test team.", 10, "password", testMember)
-        );
-        testArticle = articleRepository.save(
-                new Article(testTeam, testMember, "Test Title", "Test Body", ArticleCategory.NORMAL, new ArrayList<>())
-        );
-
-        when(imageService.articleImageUpload(new MockMultipartFile(
-                "image", "image.jpg", "image/jpeg", "mock-image-content".getBytes())))
-                .thenReturn("http://mock-s3-url.com/image.jpg");
-    }
-
-    @Test
-    @DisplayName("게시글 저장 - 유효한 데이터로 게시글 저장 성공")
-    void saveArticle_withValidData_shouldSaveSuccessfully() {
-        ArticleRequest articleRequest = new ArticleRequest(
-                testTeam.getTeamId(), "New Test Title", "New Test Body"
-        );
-        MockMultipartFile mockImage = new MockMultipartFile(
-                "image", "image.jpg", "image/jpeg", "mock-image-content".getBytes()
-        );
-
-        articleService.save(testMember.getId(), articleRequest, mockImage);
-
-        List<Article> articles = articleRepository.findAll();
-        assertThat(articles).hasSize(2);
-        Article savedArticle = articles.get(1);
-        assertThat(savedArticle.getArticleTitle()).isEqualTo("New Test Title");
-        assertThat(savedArticle.getArticleBody()).isEqualTo("New Test Body");
-    }
-
-    @Test
-    @DisplayName("게시글 저장 - 존재하지 않는 회원으로 요청 시 예외 발생")
-    void saveArticle_withNonExistingMember_shouldThrowException() {
-        ArticleRequest articleRequest = new ArticleRequest(
-                testTeam.getTeamId(), "New Test Title", "New Test Body"
-        );
-        MockMultipartFile mockImage = new MockMultipartFile(
-                "image", "image.jpg", "image/jpeg", "mock-image-content".getBytes()
-        );
-
-        assertThrows(MemberNotFoundException.class, () ->
-                articleService.save(999L, articleRequest, mockImage)
-        );
-    }
-
-    @Test
-    @DisplayName("내 게시글 조회 - 성공적으로 게시글 반환")
-    void getMyArticles_shouldReturnArticlesSuccessfully() {
-        List<Article> articles = articleService.getMyArticles(testMember.getId());
-
-        assertThat(articles).hasSize(1);
-        Article retrievedArticle = articles.get(0);
-        assertThat(retrievedArticle.getArticleTitle()).isEqualTo("Test Title");
-        assertThat(retrievedArticle.getArticleBody()).isEqualTo("Test Body");
-    }
-
-    @Test
-    @DisplayName("게시물 삭제 - 게시물 소유자가 정상적으로 삭제")
-    void deleteArticle_byOwner_shouldSucceed() {
-        articleService.deleteArticle(testArticle.getArticleId(), testMember.getId());
-
-        List<Article> articles = articleRepository.findAll();
-        assertThat(articles).isEmpty();
-    }
-
-    @Test
-    @DisplayName("게시물 수정 - 게시물 소유자가 성공적으로 수정")
-    void updateArticle_byOwner_shouldSucceed() {
-        ArticleRequest updateRequest = new ArticleRequest(
-                testArticle.getArticleId(), "Updated Title", "Updated Body"
-        );
-        MockMultipartFile mockImage = new MockMultipartFile(
-                "image", "updated.jpg", "image/jpeg", "updated-content".getBytes()
-        );
-
-        articleService.updateArticle(testArticle.getArticleId(), updateRequest, mockImage, testMember.getId());
-
-        Article updatedArticle = articleRepository.findById(testArticle.getArticleId()).orElseThrow();
-        assertThat(updatedArticle.getArticleTitle()).isEqualTo("Updated Title");
-        assertThat(updatedArticle.getArticleBody()).isEqualTo("Updated Body");
-    }
-
-    @Test
-    @DisplayName("게시물 수정 - 게시물 소유자가 아닌 경우 예외 발생")
-    void updateArticle_byNonOwner_shouldThrowException() {
-        Member anotherMember = memberRepository.save(new Member("another@example.com", "anotheruser", "USER"));
-        ArticleRequest updateRequest = new ArticleRequest(
-                testArticle.getArticleId(),"Updated Title", "Updated Body"
-        );
-        MockMultipartFile mockImage = new MockMultipartFile(
-                "image", "updated.jpg", "image/jpeg", "updated-content".getBytes()
-        );
-
-        assertThrows(UnauthorizedActionException.class, () ->
-                articleService.updateArticle(testArticle.getArticleId(), updateRequest, mockImage, anotherMember.getId())
-        );
-    }
-
-
-    /*
-    @Test
-    @DisplayName("팀 주제 저장하기 - 정상 저장")
-    void saveTeamSubject_팀_주제_정상_저장() {
-        // given
-        Long teamId = testTeam.getTeamId();
-        MockMultipartFile mockImage = new MockMultipartFile("image", "image.jpg", "image/jpeg", "mock-image-content".getBytes());
-
-        String selectedDateStr = "2024-12-02";
-        TeamSubjectRequest teamSubjectRequest = new TeamSubjectRequest("스터디", selectedDateStr, "글제목", "글내용");
+        testMember = new Member("test@example.com", "testuser", "USER");
+        testTeam = new Team("Test Team", Topic.STUDY, "This is a test team.", 10, "password", testMember);
+        mockImage = new MockMultipartFile("image", "image.jpg", "image/jpeg", "mock-image-content".getBytes());
+        imageUrl = "http://mock-s3-url.com/image.jpg";
+        selectedDateStr = "2024-12-02";
+        articleCategoryStr = "스터디";
+        articleTitle = "글제목";
+        articleBody = "글내용";
 
         LocalDate selectedDate = LocalDate.parse(selectedDateStr);
 
+        savedArticle = Article.builder()
+                .team(testTeam)
+                .member(testMember)
+                .articleTitle(articleTitle)
+                .articleBody(articleBody)
+                .articleCategory(STUDY)
+                .selectedDate(selectedDate)
+                .build();
+    }
+
+    @Test
+    @DisplayName("팀 주제 저장하기 - 정상 저장, 이미지 있음")
+    void saveTeamSubject_팀_주제_정상_저장_이미지있음() {
+        // given
+        Long teamId = testTeam.getTeamId();
+        LocalDate selectedDate = LocalDate.parse(selectedDateStr);
+
+        TeamSubjectRequest teamSubjectRequest = new TeamSubjectRequest(articleCategoryStr, selectedDateStr, articleTitle, articleBody);
+
         given(teamRepository.findById(teamId)).willReturn(Optional.of(testTeam));
-        given(articleRepository.existsByTeamAndSelectedDateAndArticleCategoryIn(testTeam, selectedDate, getSubjectCategories()));
+        given(articleRepository.existsByTeamAndSelectedDateAndArticleCategoryIn(testTeam, selectedDate, getSubjectCategories())).willReturn(false);
+        given(articleRepository.save(any(Article.class))).willReturn(savedArticle);
+        given(imageService.articleImageUpload(mockImage)).willReturn(imageUrl);
+        given(articleImageRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        Article savedTeamSubject = articleService.saveTeamSubject(testMember,teamId,teamSubjectRequest, mockImage);
+        Article savedTeamSubject = articleService.saveTeamSubject(testMember,teamId,teamSubjectRequest,mockImage);
 
         // then
         assertThat(savedTeamSubject.getArticleCategory().getName()).isEqualTo(teamSubjectRequest.articleCategory());
         assertThat(savedTeamSubject.getSelectedDate().toString()).isEqualTo(teamSubjectRequest.selectedDate());
         assertThat(savedTeamSubject.getArticleTitle()).isEqualTo(teamSubjectRequest.articleTitle());
         assertThat(savedTeamSubject.getArticleBody()).isEqualTo(teamSubjectRequest.articleBody());
-    } */
+        assertThat(savedTeamSubject.getImages().get(0).getImageUrl()).isEqualTo(imageUrl);
+        assertThat(savedTeamSubject.getTeam().getTeamId()).isEqualTo(teamId);
+        assertThat(savedTeamSubject.getMember().getUuid()).isEqualTo(testMember.getUuid());
+    }
+
+    @Test
+    @DisplayName("팀 주제 저장하기 - 정상 저장, 이미지 없음")
+    void saveTeamSubject_팀_주제_정상_저장_이미지없음() {
+        // given
+        Long teamId = testTeam.getTeamId();
+        LocalDate selectedDate = LocalDate.parse(selectedDateStr);
+
+        TeamSubjectRequest teamSubjectRequest = new TeamSubjectRequest(articleCategoryStr, selectedDateStr, articleTitle, articleBody);
+
+        given(teamRepository.findById(teamId)).willReturn(Optional.of(testTeam));
+        given(articleRepository.existsByTeamAndSelectedDateAndArticleCategoryIn(testTeam, selectedDate, getSubjectCategories())).willReturn(false);
+        given(articleRepository.save(any(Article.class))).willReturn(savedArticle);
+
+        // when
+        Article savedTeamSubject = articleService.saveTeamSubject(testMember,teamId,teamSubjectRequest,null);
+
+        // then
+        assertThat(savedTeamSubject.getArticleCategory().getName()).isEqualTo(teamSubjectRequest.articleCategory());
+        assertThat(savedTeamSubject.getSelectedDate().toString()).isEqualTo(teamSubjectRequest.selectedDate());
+        assertThat(savedTeamSubject.getArticleTitle()).isEqualTo(teamSubjectRequest.articleTitle());
+        assertThat(savedTeamSubject.getArticleBody()).isEqualTo(teamSubjectRequest.articleBody());
+        assertThat(savedTeamSubject.getImages().size()).isEqualTo(0);
+        assertThat(savedTeamSubject.getTeam().getTeamId()).isEqualTo(teamId);
+        assertThat(savedTeamSubject.getMember().getUuid()).isEqualTo(testMember.getUuid());
+    }
 
     @Test
     @DisplayName("팀 주제 저장하기 - 팀이 존재하지 않는 경우")
     void saveTeamSubject_팀_주제_팀이_존재하지_않는_경우() {
         // given
+        Long teamId = testTeam.getTeamId();
+
+        TeamSubjectRequest teamSubjectRequest = new TeamSubjectRequest(articleCategoryStr, selectedDateStr, articleTitle, articleBody);
+
+        given(teamRepository.findById(teamId)).willReturn(Optional.empty());
 
         // expected
+       assertThatThrownBy(()->articleService.saveTeamSubject(testMember,teamId,teamSubjectRequest,mockImage))
+               .isInstanceOf(TeamNotFoundException.class)
+               .hasMessage(TEAM_NOT_FOUND_ERROR.getMessage());
     }
 
     @Test
     @DisplayName("팀 주제 저장하기 - 팀 매니저가 아닌 경우")
     void saveTeamSubject_팀_매니저가_아닌_경우() {
+        // given
+        Long teamId = testTeam.getTeamId();
+        Member invalidMember = new Member("invalid", "invalid", "USER");
+
+        TeamSubjectRequest teamSubjectRequest = new TeamSubjectRequest(articleCategoryStr, selectedDateStr, articleTitle, articleBody);
+
+        given(teamRepository.findById(teamId)).willReturn(Optional.of(testTeam));
+
+        // expected
+        assertThatThrownBy(()->articleService.saveTeamSubject(invalidMember,teamId,teamSubjectRequest,mockImage))
+                .isInstanceOf(TeamManagerInvalidException.class)
+                .hasMessage(TEAM_MANAGER_INVALID_ERROR.getMessage());
     }
 
     @Test
     @DisplayName("팀 주제 저장하기 - 해당 일에 이미 주제가 등록되어 있는 경우")
     void saveTeamSubject_해당일에_주제가_이미_등록되어있는_경우() {
+        // given
+        Long teamId = testTeam.getTeamId();
+        LocalDate selectedDate = LocalDate.parse(selectedDateStr);
+
+        TeamSubjectRequest teamSubjectRequest = new TeamSubjectRequest(articleCategoryStr, selectedDateStr, articleTitle, articleBody);
+        given(teamRepository.findById(teamId)).willReturn(Optional.of(testTeam));
+        given(articleRepository.existsByTeamAndSelectedDateAndArticleCategoryIn(testTeam, selectedDate, getSubjectCategories())).willReturn(true);
+
+        // expected
+        assertThatThrownBy(()->articleService.saveTeamSubject(testMember,teamId,teamSubjectRequest,mockImage))
+                .isInstanceOf(SubjectDuplicatedException.class)
+                .hasMessage(SUBJECT_DUPLICATED_ERROR.getMessage());
     }
 
     @Test
-    @DisplayName("특정 날짜로 팀 주제 가져오기 - 정상")
-    void getTeamSubjectByDate_정상() {
+    @DisplayName("특정 날짜로 팀 주제 가져오기 - 정상: 해당 날짜에 주제 O")
+    void getTeamSubjectByDate_정상_주제_있음() {
+        // given
+        Long teamId = testTeam.getTeamId();
+        LocalDate selectedDate = LocalDate.parse(selectedDateStr);
+
+        given(teamRepository.findById(teamId)).willReturn(Optional.of(testTeam));
+        given(teamMemberRepository.existsByTeamAndMember(testTeam, testMember)).willReturn(true);
+        given(articleRepository.findTeamSubjectByTeamAndSelectedDate(teamId, selectedDate, getSubjectCategories()))
+                .willReturn(Optional.of(savedArticle));
+
+        // when
+        Article foundSubject = articleService.getTeamSubjectByDate(testMember, teamId, selectedDate);
+
+        // then
+        assertThat(foundSubject.getArticleId()).isEqualTo(savedArticle.getArticleId());
+        assertThat(foundSubject.getSelectedDate()).isEqualTo(selectedDateStr);
+    }
+
+    @Test
+    @DisplayName("특정 날짜로 팀 주제 가져오기 - 정상: 해당 날짜에 주제가 X, null 반환")
+    void getTeamSubjectByDate_정상_주제_없음() {
+        // given
+        Long teamId = testTeam.getTeamId();
+        LocalDate selectedDate = LocalDate.parse("2008-05-11");
+
+        given(teamRepository.findById(teamId)).willReturn(Optional.of(testTeam));
+        given(teamMemberRepository.existsByTeamAndMember(testTeam, testMember)).willReturn(true);
+        given(articleRepository.findTeamSubjectByTeamAndSelectedDate(teamId, selectedDate, getSubjectCategories()))
+                .willReturn(Optional.empty());
+
+        // when
+        Article foundSubject = articleService.getTeamSubjectByDate(testMember, teamId, selectedDate);
+
+        // then
+        assertThat(foundSubject).isEqualTo(null);
     }
 
     @Test
     @DisplayName("특정 날짜로 팀 주제 가져오기 - 팀이 존재하지 않는 경우")
     void getTeamSubjectByDate_팀이_존재하지_않는_경우() {
+        // given
+        Long teamId = testTeam.getTeamId();
+        LocalDate selectedDate = LocalDate.parse(selectedDateStr);
+
+        given(teamRepository.findById(teamId)).willReturn(Optional.empty());
+
+        // expected
+        assertThatThrownBy(()->articleService.getTeamSubjectByDate(testMember, teamId, selectedDate))
+                .isInstanceOf(TeamNotFoundException.class)
+                .hasMessage(TEAM_NOT_FOUND_ERROR.getMessage());
     }
 
     @Test
     @DisplayName("특정 날짜로 팀 주제 가져오기 - 팀원이 아닌 경우 ")
     void getTeamSubjectByDate_팀원이_아닌_경우() {
-    }
+        // given
+        Long teamId = testTeam.getTeamId();
+        LocalDate selectedDate = LocalDate.parse(selectedDateStr);
 
-    @Test
-    @DisplayName("특정 날짜로 팀 주제 가져오기 - 게시글이 없는 경우 ")
-    void getTeamSubjectByDate_게시글이_없는_경우() {
+        given(teamRepository.findById(teamId)).willReturn(Optional.of(testTeam));
+        given(teamMemberRepository.existsByTeamAndMember(testTeam, testMember)).willReturn(false);
+
+        // expected
+        assertThatThrownBy(()->articleService.getTeamSubjectByDate(testMember, teamId, selectedDate))
+                .isInstanceOf(TeamMemberInvalidException.class)
+                .hasMessage(TEAM_MEMBER_INVALID_ERROR.getMessage());
     }
 }


### PR DESCRIPTION
## ✏️ 변경 요약

팀 주제 등록 및 날짜로 팀 주제 조회 테스트를 작성했습니다.
글 작성일 헝태를 변경하였습니다.

## 🔍 작업 내용

1. 글 작성일 "yyyy-MM-dd HH:mm:ss" 형식으로 출력되도록 수정
2. 팀 주제 등록 api 테스트 작성
3. 날짜로 팀 주제 조회 테스트 작성

## 📌 관련된 이슈
Resolves #56 


## 📢 기타

이전에 작성중인 테스트를 주석친 상태에서 업로드하고  다시 수정하다보니 file changed가 이상합니다.
다음부터는 작업중인 테스트는 다른 곳에 옮겨놓고, 작업이 완성되면 푸쉬하겠습니다.
죄송합니다.

---

# 📋 RCA 룰

r: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)  
c: 웬만하면 반영해 주세요. (Comment)  
a: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
