### PR TITLE
Refactor/#17 관리자페이지 문제 등록 페이지 기능 개선

### DIFF
--- a/src/main/java/site/codemonster/comon/domain/problem/collector/BaekjoonCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/BaekjoonCollector.java
@@ -32,7 +32,7 @@ public class BaekjoonCollector implements ProblemCollector {
     public ProblemInfoResponse collectProblemInfo(ProblemInfoRequest request) {
         String problemId = request.getPlatformProblemId();
 
-        if (!isValidProblemId(problemId)) {
+        if (!isValidProblem(problemId)) {
             throw new ProblemInvalidInputException();
         }
 
@@ -51,7 +51,7 @@ public class BaekjoonCollector implements ProblemCollector {
     }
 
     @Override
-    public boolean isValidProblemId(String problemId) {
+    public boolean isValidProblem(String problemId) {
         if (problemId == null || problemId.trim().isEmpty()) {
             return false;
         }

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/BaekjoonCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/BaekjoonCollector.java
@@ -20,8 +20,8 @@ public class BaekjoonCollector implements ProblemCollector {
             "Unknown", "Bronze", "Silver", "Gold", "Platinum", "Diamond", "Ruby"
     );
 
-    private static final int MIN_PROBLEM_ID = 1;
-    private static final int MAX_PROBLEM_ID = 999999;
+    private static final int MIN_PROBLEM_ID = 1000;
+    private static final int MAX_PROBLEM_ID = 99999;
 
     private final RestTemplate restTemplate;
 
@@ -32,7 +32,7 @@ public class BaekjoonCollector implements ProblemCollector {
     public ProblemInfoResponse collectProblemInfo(ProblemInfoRequest request) {
         String problemId = request.getPlatformProblemId();
 
-        if (isValidProblemId(problemId)) {
+        if (!isValidProblemId(problemId)) {
             throw new ProblemInvalidInputException();
         }
 
@@ -58,7 +58,7 @@ public class BaekjoonCollector implements ProblemCollector {
 
         try {
             int id = Integer.parseInt(problemId.trim());
-            return id < MIN_PROBLEM_ID || id > MAX_PROBLEM_ID;
+            return id >= MIN_PROBLEM_ID && id <= MAX_PROBLEM_ID;
         } catch (NumberFormatException e) {
             return false;
         }

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/BaekjoonCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/BaekjoonCollector.java
@@ -4,7 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 import site.codemonster.comon.domain.problem.dto.request.ProblemInfoRequest;
 import site.codemonster.comon.domain.problem.dto.response.ProblemInfoResponse;
 import site.codemonster.comon.domain.problem.dto.response.SolvedAcAPIResponse;
@@ -23,7 +23,7 @@ public class BaekjoonCollector implements ProblemCollector {
     private static final int MIN_PROBLEM_ID = 1000;
     private static final int MAX_PROBLEM_ID = 99999;
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
 
     @Value("${problem.collection.baekjoon.problem-url}")
     private String solvedAcProblemApiUrl;
@@ -67,7 +67,11 @@ public class BaekjoonCollector implements ProblemCollector {
     private SolvedAcAPIResponse fetchProblemInfoByAPI(String problemId) {
         String apiUrl = solvedAcProblemApiUrl + "?problemId=" + problemId;
 
-        SolvedAcAPIResponse response = restTemplate.getForObject(apiUrl, SolvedAcAPIResponse.class);
+        SolvedAcAPIResponse response = restClient.get()
+                .uri(apiUrl)
+                .header("User-Agent", "Mozilla/5.0 (compatible; ProblemCollector/1.0)")
+                .retrieve()
+                .body(SolvedAcAPIResponse.class);
 
         if (response == null || response.getProblemId() == null || response.getTitleKo() == null || response.getTitleKo().trim().isEmpty()) {
             throw new ProblemNotFoundException();

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/BaekjoonCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/BaekjoonCollector.java
@@ -53,14 +53,14 @@ public class BaekjoonCollector implements ProblemCollector {
     @Override
     public boolean isValidProblemId(String problemId) {
         if (problemId == null || problemId.trim().isEmpty()) {
-            return true;
+            return false;
         }
 
         try {
             int id = Integer.parseInt(problemId.trim());
             return id < MIN_PROBLEM_ID || id > MAX_PROBLEM_ID;
         } catch (NumberFormatException e) {
-            return true;
+            return false;
         }
     }
 

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
@@ -2,7 +2,6 @@ package site.codemonster.comon.domain.problem.collector;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -11,17 +10,19 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import site.codemonster.comon.domain.problem.dto.request.ProblemInfoRequest;
 import site.codemonster.comon.domain.problem.dto.response.ProblemInfoResponse;
+import site.codemonster.comon.domain.problem.enums.LeetcodeQueryType;
 import site.codemonster.comon.domain.problem.enums.Platform;
+import site.codemonster.comon.global.error.problem.ProblemInvalidInputException;
+import site.codemonster.comon.global.error.problem.ProblemNotFoundException;
 
 import java.util.Map;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class LeetcodeCollector implements ProblemCollector {
 
+    private static final String LEETCODE_PROBLEM_URL_PREFIX = "https://leetcode.com/problems/";
     private final RestTemplate restTemplate;
-
     @Value("${problem.collection.leetcode.graphql-url:https://leetcode.com/graphql}")
     private String leetcodeGraphqlUrl;
 
@@ -29,45 +30,42 @@ public class LeetcodeCollector implements ProblemCollector {
     public ProblemInfoResponse collectProblemInfo(ProblemInfoRequest request) {
         String url = request.getPlatformProblemId();
 
-        try {
-            String slug = extractSlugFromUrl(url, true);
-
-            Map<String, Object> problemInfo = fetchProblemInfoByGraphQL(slug);
-
-            return ProblemInfoResponse.builder()
-                    .platform(Platform.LEETCODE)
-                    .platformProblemId(slug)
-                    .title((String) problemInfo.get("title"))
-                    .difficulty((String) problemInfo.get("difficulty"))
-                    .url(url)
-                    .tags(formatTags(problemInfo))
-                    .isDuplicate(false)
-                    .success(true)
-                    .build();
-
-        } catch (Exception e) {
-            log.error("리트코드 문제 정보 수집 실패: {}", e.getMessage());
-            throw new RuntimeException("리트코드 문제 정보를 찾을 수 없습니다: " + url, e);
+        if (isValidProblemId(url)) {
+            throw new ProblemInvalidInputException();
         }
+
+        String slug = extractSlugFromUrl(url, true);
+        Map<String, Object> problemInfo = fetchProblemInfoByGraphQL(slug);
+
+        return ProblemInfoResponse.builder()
+                .platform(Platform.LEETCODE)
+                .platformProblemId(slug)
+                .title((String) problemInfo.get("title"))
+                .difficulty((String) problemInfo.get("difficulty"))
+                .url(url)
+                .tags(formatTags(problemInfo))
+                .isDuplicate(false)
+                .success(true)
+                .build();
     }
 
     @Override
-    public boolean isValidProblem(String leetcodeGraphqlUrl) {
-        if (leetcodeGraphqlUrl == null || leetcodeGraphqlUrl.trim().isEmpty()) {
-            return false;
+    public boolean isValidProblemId(String leetcodeUrl) {
+        if (leetcodeUrl == null || leetcodeUrl.trim().isEmpty()) {
+            return true;
         }
 
-        String trimmedStr = leetcodeGraphqlUrl.trim();
+        String trimmedUrl = leetcodeUrl.trim();
 
-        return trimmedStr.startsWith("https://leetcode.com/problems/") &&
-                trimmedStr.contains("/problems/") &&
-                extractSlugFromUrl(trimmedStr, false) != null;
+        return !trimmedUrl.startsWith(LEETCODE_PROBLEM_URL_PREFIX) ||
+                !trimmedUrl.contains("/problems/") ||
+                extractSlugFromUrl(trimmedUrl, false) == null;
     }
 
     public String extractSlugFromUrl(String url, boolean throwException) {
         if (url == null || !url.contains("/problems/")) {
             if (throwException) {
-                throw new IllegalArgumentException("유효하지 않은 LeetCode URL입니다: " + url);
+                throw new ProblemInvalidInputException();
             }
             return null;
         }
@@ -76,6 +74,7 @@ public class LeetcodeCollector implements ProblemCollector {
             String[] parts = url.split("/problems/");
             if (parts.length > 1) {
                 String slug = parts[1].replaceAll("/$", "");
+
                 // URL에서 추가 경로나 쿼리 파라미터 제거
                 if (slug.contains("/")) {
                     slug = slug.substring(0, slug.indexOf("/"));
@@ -83,37 +82,30 @@ public class LeetcodeCollector implements ProblemCollector {
                 if (slug.contains("?")) {
                     slug = slug.substring(0, slug.indexOf("?"));
                 }
-                return slug.isEmpty() ? null : slug;
+
+                if (slug.isEmpty()) {
+                    if (throwException) {
+                        throw new ProblemInvalidInputException();
+                    }
+                    return null;
+                }
+
+                return slug;
             }
         } catch (Exception e) {
-            log.error("URL에서 slug 추출 실패: {}", url, e);
             if (throwException) {
-                throw new IllegalArgumentException("유효하지 않은 LeetCode URL입니다: " + url, e);
+                throw new ProblemInvalidInputException();
             }
         }
 
         if (throwException) {
-            throw new IllegalArgumentException("유효하지 않은 LeetCode URL입니다: " + url);
+            throw new ProblemInvalidInputException();
         }
         return null;
     }
 
     private Map<String, Object> fetchProblemInfoByGraphQL(String slug) {
-        String query = """
-            {
-                question(titleSlug: "%s") {
-                    questionId
-                    title
-                    titleSlug
-                    difficulty
-                    topicTags {
-                        name
-                    }
-                    content
-                    stats
-                }
-            }
-            """.formatted(slug);
+        String query = LeetcodeQueryType.PROBLEM_DETAIL.formatQuery(slug);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -122,29 +114,18 @@ public class LeetcodeCollector implements ProblemCollector {
         Map<String, Object> requestBody = Map.of("query", query);
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
 
-        try {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> response = restTemplate.postForObject(leetcodeGraphqlUrl, request, Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> response = restTemplate.postForObject(leetcodeGraphqlUrl, request, Map.class);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) response.get("data");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> question = (Map<String, Object>) data.get("question");
 
-            if (response == null || !response.containsKey("data")) {
-                throw new RuntimeException("GraphQL 응답이 올바르지 않습니다");
-            }
-
-            @SuppressWarnings("unchecked")
-            Map<String, Object> data = (Map<String, Object>) response.get("data");
-            @SuppressWarnings("unchecked")
-            Map<String, Object> question = (Map<String, Object>) data.get("question");
-
-            if (question == null) {
-                throw new RuntimeException("문제를 찾을 수 없습니다: " + slug);
-            }
-
-            return question;
-
-        } catch (Exception e) {
-            log.error("LeetCode GraphQL API 호출 실패: {}", e.getMessage());
-            throw new RuntimeException("LeetCode 문제 정보를 가져오는 데 실패했습니다: " + slug, e);
+        if (question == null || question.get("title") == null || question.get("difficulty") == null) {
+            throw new ProblemNotFoundException();
         }
+
+        return question;
     }
 
     private String formatTags(Map<String, Object> problemInfo) {
@@ -159,11 +140,11 @@ public class LeetcodeCollector implements ProblemCollector {
 
             return topicTags.stream()
                     .map(tag -> (String) tag.get("name"))
+                    .filter(name -> name != null && !name.trim().isEmpty())
                     .reduce((a, b) -> a + "," + b)
                     .orElse("");
 
         } catch (Exception e) {
-            log.warn("태그 정보 파싱 실패: {}", e.getMessage());
             return "";
         }
     }

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
@@ -30,7 +30,7 @@ public class LeetcodeCollector implements ProblemCollector {
     public ProblemInfoResponse collectProblemInfo(ProblemInfoRequest request) {
         String url = request.getPlatformProblemId();
 
-        if (isValidProblemId(url)) {
+        if (!isValidProblemId(url)) {
             throw new ProblemInvalidInputException();
         }
 
@@ -58,7 +58,6 @@ public class LeetcodeCollector implements ProblemCollector {
         String trimmedUrl = leetcodeUrl.trim();
 
         return trimmedUrl.startsWith(LEETCODE_PROBLEM_URL_PREFIX) &&
-                trimmedUrl.contains("/problems/") &&
                 extractSlugFromUrl(trimmedUrl, false) != null;
     }
 

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
@@ -52,14 +52,13 @@ public class LeetcodeCollector implements ProblemCollector {
     @Override
     public boolean isValidProblemId(String leetcodeUrl) {
         if (leetcodeUrl == null || leetcodeUrl.trim().isEmpty()) {
-            return true;
+            return false;
         }
 
         String trimmedUrl = leetcodeUrl.trim();
-
-        return !trimmedUrl.startsWith(LEETCODE_PROBLEM_URL_PREFIX) ||
-                !trimmedUrl.contains("/problems/") ||
-                extractSlugFromUrl(trimmedUrl, false) == null;
+        return trimmedUrl.startsWith(LEETCODE_PROBLEM_URL_PREFIX) &&
+                trimmedUrl.contains("/problems/") &&
+                extractSlugFromUrl(trimmedUrl, false) != null;
     }
 
     public String extractSlugFromUrl(String url, boolean throwException) {

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
@@ -30,7 +30,7 @@ public class LeetcodeCollector implements ProblemCollector {
     public ProblemInfoResponse collectProblemInfo(ProblemInfoRequest request) {
         String url = request.getPlatformProblemId();
 
-        if (!isValidProblemId(url)) {
+        if (!isValidProblem(url)) {
             throw new ProblemInvalidInputException();
         }
 
@@ -50,7 +50,7 @@ public class LeetcodeCollector implements ProblemCollector {
     }
 
     @Override
-    public boolean isValidProblemId(String leetcodeUrl) {
+    public boolean isValidProblem(String leetcodeUrl) {
         if (leetcodeUrl == null || leetcodeUrl.trim().isEmpty()) {
             return false;
         }

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
@@ -122,21 +122,16 @@ public class LeetcodeCollector implements ProblemCollector {
     }
 
     private String formatTags(LeetcodeAPIResponse response) {
-        try {
-            List<Map<String, Object>> topicTags = response.getTopicTags();
+        List<LeetcodeAPIResponse.TopicTag> topicTags = response.getTopicTags();
 
-            if (topicTags == null || topicTags.isEmpty()) {
-                return "";
-            }
-
-            return topicTags.stream()
-                    .map(tag -> (String) tag.get("name"))
-                    .filter(name -> name != null && !name.trim().isEmpty())
-                    .reduce((a, b) -> a + "," + b)
-                    .orElse("");
-
-        } catch (Exception e) {
+        if (topicTags == null || topicTags.isEmpty()) {
             return "";
         }
+
+        return topicTags.stream()
+                .map(LeetcodeAPIResponse.TopicTag::getName)
+                .filter(name -> name != null && !name.trim().isEmpty())
+                .reduce((a, b) -> a + "," + b)
+                .orElse("");
     }
 }

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/LeetcodeCollector.java
@@ -56,6 +56,7 @@ public class LeetcodeCollector implements ProblemCollector {
         }
 
         String trimmedUrl = leetcodeUrl.trim();
+
         return trimmedUrl.startsWith(LEETCODE_PROBLEM_URL_PREFIX) &&
                 trimmedUrl.contains("/problems/") &&
                 extractSlugFromUrl(trimmedUrl, false) != null;

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/ProblemCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/ProblemCollector.java
@@ -7,5 +7,5 @@ public interface ProblemCollector {
 
     ProblemInfoResponse collectProblemInfo(ProblemInfoRequest request);
 
-    boolean isValidProblem(String problemId);
+    boolean isValidProblemId(String problemId);
 }

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/ProblemCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/ProblemCollector.java
@@ -7,5 +7,5 @@ public interface ProblemCollector {
 
     ProblemInfoResponse collectProblemInfo(ProblemInfoRequest request);
 
-    boolean isValidProblemId(String problemId);
+    boolean isValidProblem(String problemId);
 }

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/ProgrammersCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/ProgrammersCollector.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Component;
 import site.codemonster.comon.domain.problem.dto.request.ProblemInfoRequest;
 import site.codemonster.comon.domain.problem.dto.response.ProblemInfoResponse;
 import site.codemonster.comon.domain.problem.enums.Platform;
-import site.codemonster.comon.global.error.problem.ProblemInvalidInputException;
 import site.codemonster.comon.global.error.problem.ProblemValidationException;
 
 import java.util.Set;
@@ -18,8 +17,8 @@ public class ProgrammersCollector implements ProblemCollector {
             "Level 0", "Level 1", "Level 2", "Level 3", "Level 4", "Level 5"
     );
 
-    private static final int MIN_PROBLEM_ID = 1;
-    private static final int MAX_PROBLEM_ID = 999999;
+    private static final int MIN_PROBLEM_ID = 10000;
+    private static final int MAX_PROBLEM_ID = 99999;
     private static final int MAX_TITLE_LENGTH = 50;
     private static final int MAX_TAGS_LENGTH = 50;
 
@@ -54,11 +53,6 @@ public class ProgrammersCollector implements ProblemCollector {
     }
 
     private void validateRequest(ProblemInfoRequest request) {
-        // 플랫폼 문제 ID 검증
-        if (isValidProblemId(request.getPlatformProblemId())) {
-            throw new ProblemInvalidInputException();
-        }
-
         // 제목 검증
         if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
             throw new ProblemValidationException(PROBLEM_TITLE_REQUIRED_ERROR);

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/ProgrammersCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/ProgrammersCollector.java
@@ -39,7 +39,7 @@ public class ProgrammersCollector implements ProblemCollector {
     }
 
     @Override
-    public boolean isValidProblemId(String problemId) {
+    public boolean isValidProblem(String problemId) {
         if (problemId == null || problemId.trim().isEmpty()) {
             return false;
         }

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/ProgrammersCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/ProgrammersCollector.java
@@ -42,14 +42,14 @@ public class ProgrammersCollector implements ProblemCollector {
     @Override
     public boolean isValidProblemId(String problemId) {
         if (problemId == null || problemId.trim().isEmpty()) {
-            return true;
+            return false;
         }
 
         try {
             int id = Integer.parseInt(problemId.trim());
-            return id < MIN_PROBLEM_ID || id > MAX_PROBLEM_ID;
+            return id >= MIN_PROBLEM_ID && id <= MAX_PROBLEM_ID;
         } catch (NumberFormatException e) {
-            return true;
+            return false;
         }
     }
 

--- a/src/main/java/site/codemonster/comon/domain/problem/collector/ProgrammersCollector.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/collector/ProgrammersCollector.java
@@ -1,87 +1,91 @@
 package site.codemonster.comon.domain.problem.collector;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import site.codemonster.comon.domain.problem.dto.request.ProblemInfoRequest;
 import site.codemonster.comon.domain.problem.dto.response.ProblemInfoResponse;
 import site.codemonster.comon.domain.problem.enums.Platform;
+import site.codemonster.comon.global.error.problem.ProblemInvalidInputException;
+import site.codemonster.comon.global.error.problem.ProblemValidationException;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.Set;
 
-@Slf4j
+import static site.codemonster.comon.global.error.ErrorCode.*;
+
 @Component
 public class ProgrammersCollector implements ProblemCollector {
 
-    private static final List<String> PROGRAMMERS_LEVELS = Arrays.asList(
+    private static final Set<String> VALID_PROGRAMMERS_LEVELS = Set.of(
             "Level 0", "Level 1", "Level 2", "Level 3", "Level 4", "Level 5"
     );
+
+    private static final int MIN_PROBLEM_ID = 1;
+    private static final int MAX_PROBLEM_ID = 999999;
+    private static final int MAX_TITLE_LENGTH = 50;
+    private static final int MAX_TAGS_LENGTH = 50;
 
     @Override
     public ProblemInfoResponse collectProblemInfo(ProblemInfoRequest request) {
         validateRequest(request);
 
-        try {
-            String url = "https://school.programmers.co.kr/learn/courses/30/lessons/" + request.getPlatformProblemId();
-
-            return ProblemInfoResponse.builder()
-                    .platform(Platform.PROGRAMMERS)
-                    .platformProblemId(request.getPlatformProblemId())
-                    .title(request.getTitle())
-                    .difficulty(request.getDifficulty())
-                    .url(url)
-                    .tags(request.getTags() != null ? request.getTags() : "")
-                    .isDuplicate(false)
-                    .success(true)
-                    .build();
-
-        } catch (Exception e) {
-            log.error("프로그래머스 문제 정보 처리 실패: {}", e.getMessage());
-            throw new RuntimeException("프로그래머스 문제 정보 처리에 실패했습니다", e);
-        }
+        return ProblemInfoResponse.builder()
+                .platform(Platform.PROGRAMMERS)
+                .platformProblemId(request.getPlatformProblemId())
+                .title(request.getTitle().trim())
+                .difficulty(request.getDifficulty())
+                .url(buildProgrammersUrl(request.getPlatformProblemId()))
+                .tags(request.getTags() != null ? request.getTags().trim() : "")
+                .isDuplicate(false)
+                .success(true)
+                .build();
     }
 
     @Override
-    public boolean isValidProblem(String problemId) {
+    public boolean isValidProblemId(String problemId) {
         if (problemId == null || problemId.trim().isEmpty()) {
-            return false;
+            return true;
         }
 
         try {
             int id = Integer.parseInt(problemId.trim());
-            return id > 0 && id <= 999999;
+            return id < MIN_PROBLEM_ID || id > MAX_PROBLEM_ID;
         } catch (NumberFormatException e) {
-            return false;
+            return true;
         }
     }
 
     private void validateRequest(ProblemInfoRequest request) {
-        if (request.getPlatformProblemId() == null || request.getPlatformProblemId().trim().isEmpty()) {
-            throw new IllegalArgumentException("문제번호를 입력해주세요.");
+        // 플랫폼 문제 ID 검증
+        if (isValidProblemId(request.getPlatformProblemId())) {
+            throw new ProblemInvalidInputException();
         }
 
+        // 제목 검증
         if (request.getTitle() == null || request.getTitle().trim().isEmpty()) {
-            throw new IllegalArgumentException("문제 제목을 입력해주세요.");
+            throw new ProblemValidationException(PROBLEM_TITLE_REQUIRED_ERROR);
         }
 
+        // 제목 길이 검증
+        if (request.getTitle().length() > MAX_TITLE_LENGTH) {
+            throw new ProblemValidationException(PROBLEM_TITLE_TOO_LONG_ERROR);
+        }
+
+        // 난이도 검증
         if (request.getDifficulty() == null || request.getDifficulty().trim().isEmpty()) {
-            throw new IllegalArgumentException("난이도를 선택해주세요.");
+            throw new ProblemValidationException(PROBLEM_DIFFICULTY_REQUIRED_ERROR);
         }
 
-        if (!PROGRAMMERS_LEVELS.contains(request.getDifficulty())) {
-            throw new IllegalArgumentException("유효하지 않은 난이도입니다: " + request.getDifficulty());
+        // 난이도 값이 유효한지 확인
+        if (!VALID_PROGRAMMERS_LEVELS.contains(request.getDifficulty())) {
+            throw new ProblemValidationException(PROBLEM_DIFFICULTY_INVALID_ERROR);
         }
 
-        if (!isValidProblem(request.getPlatformProblemId())) {
-            throw new IllegalArgumentException("유효하지 않은 문제번호입니다: " + request.getPlatformProblemId());
+        // 태그 검증
+        if (request.getTags() != null && request.getTags().length() > MAX_TAGS_LENGTH) {
+            throw new ProblemValidationException(PROBLEM_TAGS_TOO_LONG_ERROR);
         }
+    }
 
-        if (request.getTitle().length() > 100) {
-            throw new IllegalArgumentException("제목이 너무 깁니다. (최대 100자)");
-        }
-
-        if (request.getTags() != null && request.getTags().length() > 200) {
-            throw new IllegalArgumentException("태그가 너무 깁니다. (최대 200자)");
-        }
+    private String buildProgrammersUrl(String problemId) {
+        return "https://school.programmers.co.kr/learn/courses/30/lessons/" + problemId;
     }
 }

--- a/src/main/java/site/codemonster/comon/domain/problem/controller/AdminProblemApiController.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/controller/AdminProblemApiController.java
@@ -12,7 +12,8 @@ import site.codemonster.comon.domain.problem.dto.request.ProblemInfoRequest;
 import site.codemonster.comon.domain.problem.dto.response.ProblemInfoResponse;
 import site.codemonster.comon.domain.problem.entity.Problem;
 import site.codemonster.comon.domain.problem.enums.Platform;
-import site.codemonster.comon.domain.problem.service.ProblemService;
+import site.codemonster.comon.domain.problem.service.ProblemCommandService;
+import site.codemonster.comon.domain.problem.service.ProblemQueryService;
 import site.codemonster.comon.global.error.dto.response.ApiResponse;
 
 import java.util.List;
@@ -23,11 +24,12 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AdminProblemApiController {
 
-    private final ProblemService problemService;
+    private final ProblemCommandService problemCommandService;
+    private final ProblemQueryService problemQueryService;
 
     @PostMapping("/check/baekjoon")
     public ResponseEntity<?> checkBaekjoonProblem(@RequestParam String problemId) {
-        ProblemInfoResponse response = problemService.checkProblem(problemId, Platform.BAEKJOON);
+        ProblemInfoResponse response = problemCommandService.checkProblem(problemId, Platform.BAEKJOON);
 
         return ResponseEntity.status(PROBLEM_CHECK_SUCCESS.getStatusCode())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -38,7 +40,7 @@ public class AdminProblemApiController {
     public ResponseEntity<?> checkProgrammersProblem(@RequestBody @Valid ProblemInfoRequest request) {
         if (request.getPlatform() == null) request.setPlatform(Platform.PROGRAMMERS);
 
-        ProblemInfoResponse response = problemService.checkProblem(request);
+        ProblemInfoResponse response = problemCommandService.checkProblem(request);
 
         return ResponseEntity.status(PROBLEM_CHECK_SUCCESS.getStatusCode())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -47,7 +49,7 @@ public class AdminProblemApiController {
 
     @PostMapping("/check/leetcode")
     public ResponseEntity<?> checkLeetcodeProblem(@RequestParam String url) {
-        ProblemInfoResponse response = problemService.checkProblem(url, Platform.LEETCODE);
+        ProblemInfoResponse response = problemCommandService.checkProblem(url, Platform.LEETCODE);
 
         return ResponseEntity.status(PROBLEM_CHECK_SUCCESS.getStatusCode())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -56,7 +58,7 @@ public class AdminProblemApiController {
 
     @PostMapping("/register/batch")
     public ResponseEntity<?> registerProblems(@RequestBody @Valid ProblemBatchRequest batchRequest) {
-        List<Problem> savedProblems = problemService.registerProblems(batchRequest.getProblems());
+        List<Problem> savedProblems = problemCommandService.registerProblems(batchRequest.getProblems());
 
         Map<String, Object> responseData = Map.of(
                 "count", savedProblems.size(),
@@ -70,7 +72,7 @@ public class AdminProblemApiController {
 
     @GetMapping("/statistics")
     public ResponseEntity<?> getProblemStatistics() {
-        Map<Platform, Long> statistics = problemService.getProblemStatistics();
+        Map<Platform, Long> statistics = problemQueryService.getProblemStatistics();
 
         return ResponseEntity.status(PROBLEM_STATISTICS_GET_SUCCESS.getStatusCode())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -79,7 +81,7 @@ public class AdminProblemApiController {
 
     @GetMapping("/api/list")
     public ResponseEntity<?> getProblemList() {
-        List<Problem> problems = problemService.getAllProblems();
+        List<Problem> problems = problemQueryService.getAllProblems();
 
         return ResponseEntity.status(PROBLEM_LIST_GET_SUCCESS.getStatusCode())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -88,7 +90,7 @@ public class AdminProblemApiController {
 
     @GetMapping("/api/list-by-platform")
     public ResponseEntity<?> getProblemListByPlatform(@RequestParam(required = false) String platform) {
-        List<Problem> problems = problemService.getProblemsByPlatform(Platform.valueOf(platform.toUpperCase()));
+        List<Problem> problems = problemQueryService.getProblemsByPlatform(Platform.valueOf(platform.toUpperCase()));
 
         return ResponseEntity.status(PROBLEM_LIST_GET_SUCCESS.getStatusCode())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -97,7 +99,7 @@ public class AdminProblemApiController {
 
     @PutMapping("/api/{problemId}")
     public ResponseEntity<?> updateProblem(@PathVariable Long problemId, @RequestBody Map<String, String> updateData) {
-        Problem updatedProblem = problemService.updateProblem(problemId, updateData);
+        Problem updatedProblem = problemCommandService.updateProblem(problemId, updateData);
 
         return ResponseEntity.status(PROBLEM_UPDATE_SUCCESS.getStatusCode())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -106,7 +108,7 @@ public class AdminProblemApiController {
 
     @DeleteMapping("/api/{problemId}")
     public ResponseEntity<?> deleteProblem(@PathVariable Long problemId) {
-        problemService.deleteProblem(problemId);
+        problemCommandService.deleteProblem(problemId);
 
         return ResponseEntity.status(PROBLEM_DELETE_SUCCESS.getStatusCode())
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/main/java/site/codemonster/comon/domain/problem/controller/AdminProblemApiController.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/controller/AdminProblemApiController.java
@@ -1,6 +1,11 @@
 package site.codemonster.comon.domain.problem.controller;
 
+import static site.codemonster.comon.domain.problem.controller.ProblemResponseEnum.*;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.codemonster.comon.domain.problem.dto.request.ProblemBatchRequest;
 import site.codemonster.comon.domain.problem.dto.request.ProblemInfoRequest;
@@ -8,11 +13,10 @@ import site.codemonster.comon.domain.problem.dto.response.ProblemInfoResponse;
 import site.codemonster.comon.domain.problem.entity.Problem;
 import site.codemonster.comon.domain.problem.enums.Platform;
 import site.codemonster.comon.domain.problem.service.ProblemService;
+import site.codemonster.comon.global.error.dto.response.ApiResponse;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/admin/problems")
@@ -22,134 +26,90 @@ public class AdminProblemApiController {
     private final ProblemService problemService;
 
     @PostMapping("/check/baekjoon")
-    public Map<String, Object> checkBaekjoonProblem(@RequestParam String problemId) {
-        try {
-            ProblemInfoResponse response = problemService.checkProblem(problemId, Platform.BAEKJOON);
-            return toResponseMap(response);
-        } catch (Exception e) {
-            return Map.of("success", false, "errorMessage", "문제 정보를 찾을 수 없습니다: " + e.getMessage());
-        }
+    public ResponseEntity<?> checkBaekjoonProblem(@RequestParam String problemId) {
+        ProblemInfoResponse response = problemService.checkProblem(problemId, Platform.BAEKJOON);
+
+        return ResponseEntity.status(PROBLEM_CHECK_SUCCESS.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponse(response, PROBLEM_CHECK_SUCCESS.getMessage()));
     }
 
     @PostMapping("/check/programmers")
-    public Map<String, Object> checkProgrammersProblem(@RequestBody ProblemInfoRequest request) {
-        try {
-            if (request.getPlatform() == null) {
-                request.setPlatform(Platform.PROGRAMMERS);
-            }
-            ProblemInfoResponse response = problemService.checkProblem(request);
-            return toResponseMap(response);
-        } catch (Exception e) {
-            return Map.of("success", false, "errorMessage", "입력 정보를 확인해주세요: " + e.getMessage());
-        }
+    public ResponseEntity<?> checkProgrammersProblem(@RequestBody @Valid ProblemInfoRequest request) {
+        if (request.getPlatform() == null) request.setPlatform(Platform.PROGRAMMERS);
+
+        ProblemInfoResponse response = problemService.checkProblem(request);
+
+        return ResponseEntity.status(PROBLEM_CHECK_SUCCESS.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponse(response, PROBLEM_CHECK_SUCCESS.getMessage()));
     }
 
     @PostMapping("/check/leetcode")
-    public Map<String, Object> checkLeetcodeProblem(@RequestParam String url) {
-        try {
-            ProblemInfoResponse response = problemService.checkProblem(url, Platform.LEETCODE);
-            return toResponseMap(response);
-        } catch (Exception e) {
-            return Map.of("success", false, "errorMessage", "문제 정보를 찾을 수 없습니다: " + e.getMessage());
-        }
+    public ResponseEntity<?> checkLeetcodeProblem(@RequestParam String url) {
+        ProblemInfoResponse response = problemService.checkProblem(url, Platform.LEETCODE);
+
+        return ResponseEntity.status(PROBLEM_CHECK_SUCCESS.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponse(response, PROBLEM_CHECK_SUCCESS.getMessage()));
     }
 
     @PostMapping("/register/batch")
-    public Map<String, Object> registerProblems(@RequestBody ProblemBatchRequest batchRequest) {
-        try {
-            List<Problem> savedProblems = problemService.registerProblems(batchRequest.getProblems());
-            return Map.of(
-                    "success", true,
-                    "message", savedProblems.size() + "개 문제가 성공적으로 등록되었습니다.",
-                    "count", savedProblems.size()
-            );
-        } catch (Exception e) {
-            return Map.of("success", false, "message", "문제 등록에 실패했습니다: " + e.getMessage());
-        }
+    public ResponseEntity<?> registerProblems(@RequestBody @Valid ProblemBatchRequest batchRequest) {
+        List<Problem> savedProblems = problemService.registerProblems(batchRequest.getProblems());
+
+        Map<String, Object> responseData = Map.of(
+                "count", savedProblems.size(),
+                "message", savedProblems.size() + "개 문제가 성공적으로 등록되었습니다."
+        );
+
+        return ResponseEntity.status(PROBLEM_BATCH_REGISTER_SUCCESS.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.createResponse(responseData, PROBLEM_BATCH_REGISTER_SUCCESS.getMessage()));
     }
 
     @GetMapping("/statistics")
-    public Map<Platform, Long> getProblemStatistics() {
-        return problemService.getProblemStatistics();
+    public ResponseEntity<?> getProblemStatistics() {
+        Map<Platform, Long> statistics = problemService.getProblemStatistics();
+
+        return ResponseEntity.status(PROBLEM_STATISTICS_GET_SUCCESS.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponse(statistics, PROBLEM_STATISTICS_GET_SUCCESS.getMessage()));
     }
 
     @GetMapping("/api/list")
-    public List<Map<String, Object>> getProblemList() {
-        try {
-            return problemService.getAllProblems()
-                    .stream()
-                    .map(this::toProblemMap)
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            return Collections.emptyList();
-        }
+    public ResponseEntity<?> getProblemList() {
+        List<Problem> problems = problemService.getAllProblems();
+
+        return ResponseEntity.status(PROBLEM_LIST_GET_SUCCESS.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponse(problems, PROBLEM_LIST_GET_SUCCESS.getMessage()));
     }
 
     @GetMapping("/api/list-by-platform")
-    public List<Map<String, Object>> getProblemListByPlatform(@RequestParam(required = false) String platform) {
-        try {
-            if (platform == null || platform.isEmpty()) {
-                return Collections.emptyList();
-            }
+    public ResponseEntity<?> getProblemListByPlatform(@RequestParam(required = false) String platform) {
+        List<Problem> problems = problemService.getProblemsByPlatform(Platform.valueOf(platform.toUpperCase()));
 
-            List<Problem> problems = problemService.getProblemsByPlatform(Platform.valueOf(platform.toUpperCase()));
-
-            return problems.stream()
-                    .map(this::toProblemMap)
-                    .collect(Collectors.toList());
-        } catch (Exception e) {
-            return Collections.emptyList();
-        }
+        return ResponseEntity.status(PROBLEM_LIST_GET_SUCCESS.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponse(problems, PROBLEM_LIST_GET_SUCCESS.getMessage()));
     }
 
     @PutMapping("/api/{problemId}")
-    public Map<String, Object> updateProblem(@PathVariable Long problemId, @RequestBody Map<String, String> updateData) {
-        try {
-            Problem updatedProblem = problemService.updateProblem(problemId, updateData);
-            return Map.of(
-                    "success", true,
-                    "message", "문제가 성공적으로 수정되었습니다.",
-                    "problem", updatedProblem
-            );
-        } catch (Exception e) {
-            return Map.of("success", false, "message", "문제 수정에 실패했습니다: " + e.getMessage());
-        }
+    public ResponseEntity<?> updateProblem(@PathVariable Long problemId, @RequestBody Map<String, String> updateData) {
+        Problem updatedProblem = problemService.updateProblem(problemId, updateData);
+
+        return ResponseEntity.status(PROBLEM_UPDATE_SUCCESS.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponse(updatedProblem, PROBLEM_UPDATE_SUCCESS.getMessage()));
     }
 
     @DeleteMapping("/api/{problemId}")
-    public Map<String, Object> deleteProblem(@PathVariable Long problemId) {
-        try {
-            problemService.deleteProblem(problemId);
-            return Map.of("success", true, "message", "문제가 성공적으로 삭제되었습니다.");
-        } catch (Exception e) {
-            return Map.of("success", false, "message", "문제 삭제에 실패했습니다: " + e.getMessage());
-        }
-    }
+    public ResponseEntity<?> deleteProblem(@PathVariable Long problemId) {
+        problemService.deleteProblem(problemId);
 
-    private Map<String, Object> toResponseMap(ProblemInfoResponse response) {
-        return Map.of(
-                "success", response.isSuccess(),
-                "isDuplicate", response.isDuplicate(),
-                "platform", response.getPlatform().name(),
-                "platformProblemId", response.getPlatformProblemId(),
-                "title", response.getTitle(),
-                "difficulty", response.getDifficulty(),
-                "url", response.getUrl(),
-                "tags", response.getTags()
-        );
-    }
-
-    private Map<String, Object> toProblemMap(Problem problem) {
-        return Map.of(
-                "problemId", problem.getProblemId(),
-                "platform", problem.getPlatform().name(),
-                "platformProblemId", problem.getPlatformProblemId(),
-                "title", problem.getTitle(),
-                "difficulty", problem.getDifficulty(),
-                "url", problem.getUrl(),
-                "tags", problem.getTags(),
-                "createdAt", problem.getCreatedDate() != null ? problem.getCreatedDate().toString() : null,
-                "updatedAt", problem.getUpdatedDate() != null ? problem.getUpdatedDate().toString() : null
-        );
+        return ResponseEntity.status(PROBLEM_DELETE_SUCCESS.getStatusCode())
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponseWithMessage(PROBLEM_DELETE_SUCCESS.getMessage()));
     }
 }

--- a/src/main/java/site/codemonster/comon/domain/problem/controller/AdminProblemApiController.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/controller/AdminProblemApiController.java
@@ -27,8 +27,8 @@ public class AdminProblemApiController {
     private final ProblemCommandService problemCommandService;
     private final ProblemQueryService problemQueryService;
 
-    @PostMapping("/check/baekjoon")
-    public ResponseEntity<?> checkBaekjoonProblem(@RequestParam String problemId) {
+    @PostMapping("/get/baekjoon")
+    public ResponseEntity<?> getBaekjoonProblemInfo(@RequestParam String problemId) {
         ProblemInfoResponse response = problemCommandService.checkProblem(problemId, Platform.BAEKJOON);
 
         return ResponseEntity.status(PROBLEM_CHECK_SUCCESS.getStatusCode())
@@ -36,8 +36,8 @@ public class AdminProblemApiController {
                 .body(ApiResponse.successResponse(response, PROBLEM_CHECK_SUCCESS.getMessage()));
     }
 
-    @PostMapping("/check/programmers")
-    public ResponseEntity<?> checkProgrammersProblem(@RequestBody @Valid ProblemInfoRequest request) {
+    @PostMapping("/get/programmers")
+    public ResponseEntity<?> getProgrammersProblemInfo(@RequestBody @Valid ProblemInfoRequest request) {
         if (request.getPlatform() == null) request.setPlatform(Platform.PROGRAMMERS);
 
         ProblemInfoResponse response = problemCommandService.checkProblem(request);
@@ -47,8 +47,8 @@ public class AdminProblemApiController {
                 .body(ApiResponse.successResponse(response, PROBLEM_CHECK_SUCCESS.getMessage()));
     }
 
-    @PostMapping("/check/leetcode")
-    public ResponseEntity<?> checkLeetcodeProblem(@RequestParam String url) {
+    @PostMapping("/get/leetcode")
+    public ResponseEntity<?> getLeetcodeProblemInfo(@RequestParam String url) {
         ProblemInfoResponse response = problemCommandService.checkProblem(url, Platform.LEETCODE);
 
         return ResponseEntity.status(PROBLEM_CHECK_SUCCESS.getStatusCode())
@@ -56,7 +56,7 @@ public class AdminProblemApiController {
                 .body(ApiResponse.successResponse(response, PROBLEM_CHECK_SUCCESS.getMessage()));
     }
 
-    @PostMapping("/register/batch")
+    @PostMapping("/register")
     public ResponseEntity<?> registerProblems(@RequestBody @Valid ProblemBatchRequest batchRequest) {
         List<Problem> savedProblems = problemCommandService.registerProblems(batchRequest.getProblems());
 
@@ -79,7 +79,7 @@ public class AdminProblemApiController {
                 .body(ApiResponse.successResponse(statistics, PROBLEM_STATISTICS_GET_SUCCESS.getMessage()));
     }
 
-    @GetMapping("/api/list")
+    @GetMapping("/problem-list")
     public ResponseEntity<?> getProblemList() {
         List<Problem> problems = problemQueryService.getAllProblems();
 
@@ -88,7 +88,7 @@ public class AdminProblemApiController {
                 .body(ApiResponse.successResponse(problems, PROBLEM_LIST_GET_SUCCESS.getMessage()));
     }
 
-    @GetMapping("/api/list-by-platform")
+    @GetMapping("/list-by-platform")
     public ResponseEntity<?> getProblemListByPlatform(@RequestParam String platform) {
         List<Problem> problems = problemQueryService.getProblemsByPlatform(Platform.valueOf(platform.toUpperCase()));
 
@@ -97,7 +97,7 @@ public class AdminProblemApiController {
                 .body(ApiResponse.successResponse(problems, PROBLEM_LIST_GET_SUCCESS.getMessage()));
     }
 
-    @PutMapping("/api/{problemId}")
+    @PutMapping("/{problemId}")
     public ResponseEntity<?> updateProblem(@PathVariable Long problemId, @RequestBody Map<String, String> updateData) {
         Problem updatedProblem = problemCommandService.updateProblem(problemId, updateData);
 
@@ -106,7 +106,7 @@ public class AdminProblemApiController {
                 .body(ApiResponse.successResponse(updatedProblem, PROBLEM_UPDATE_SUCCESS.getMessage()));
     }
 
-    @DeleteMapping("/api/{problemId}")
+    @DeleteMapping("/{problemId}")
     public ResponseEntity<?> deleteProblem(@PathVariable Long problemId) {
         problemCommandService.deleteProblem(problemId);
 

--- a/src/main/java/site/codemonster/comon/domain/problem/controller/AdminProblemApiController.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/controller/AdminProblemApiController.java
@@ -89,7 +89,7 @@ public class AdminProblemApiController {
     }
 
     @GetMapping("/api/list-by-platform")
-    public ResponseEntity<?> getProblemListByPlatform(@RequestParam(required = false) String platform) {
+    public ResponseEntity<?> getProblemListByPlatform(@RequestParam String platform) {
         List<Problem> problems = problemQueryService.getProblemsByPlatform(Platform.valueOf(platform.toUpperCase()));
 
         return ResponseEntity.status(PROBLEM_LIST_GET_SUCCESS.getStatusCode())

--- a/src/main/java/site/codemonster/comon/domain/problem/controller/AdminProblemPageController.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/controller/AdminProblemPageController.java
@@ -11,7 +11,7 @@ import site.codemonster.comon.domain.adminAuth.controller.AdminAuthPageControlle
 import site.codemonster.comon.domain.adminAuth.entity.AdminMember;
 import site.codemonster.comon.domain.problem.dto.request.ProblemInfoRequest;
 import site.codemonster.comon.domain.problem.enums.Platform;
-import site.codemonster.comon.domain.problem.service.ProblemService;
+import site.codemonster.comon.domain.problem.service.ProblemQueryService;
 
 @Slf4j
 @Controller
@@ -19,7 +19,7 @@ import site.codemonster.comon.domain.problem.service.ProblemService;
 @RequiredArgsConstructor
 public class AdminProblemPageController {
 
-    private final ProblemService problemService;
+    private final ProblemQueryService problemQueryService;
 
     // 관리자 메인 페이지
     @GetMapping
@@ -33,7 +33,7 @@ public class AdminProblemPageController {
         addAdminInfoToModel(model, session);
 
         // 플랫폼별 문제 통계
-        Map<Platform, Long> statistics = problemService.getProblemStatistics();
+        Map<Platform, Long> statistics = problemQueryService.getProblemStatistics();
         model.addAttribute("statistics", statistics);
 
         // 전체 문제 수

--- a/src/main/java/site/codemonster/comon/domain/problem/controller/ProblemResponseEnum.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/controller/ProblemResponseEnum.java
@@ -1,0 +1,30 @@
+package site.codemonster.comon.domain.problem.controller;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProblemResponseEnum {
+
+    // 문제 체크 관련
+    PROBLEM_CHECK_SUCCESS("문제 정보 조회에 성공했습니다.", HttpStatus.OK.value()),
+    PROBLEM_CHECK_DUPLICATE("이미 등록된 문제입니다.", HttpStatus.OK.value()),
+
+    // 문제 등록 관련
+    PROBLEM_BATCH_REGISTER_SUCCESS("문제 일괄 등록에 성공했습니다.", HttpStatus.CREATED.value()),
+
+    // 문제 수정 관련
+    PROBLEM_UPDATE_SUCCESS("문제 정보 수정에 성공했습니다.", HttpStatus.OK.value()),
+
+    // 문제 삭제 관련
+    PROBLEM_DELETE_SUCCESS("문제 삭제에 성공했습니다.", HttpStatus.OK.value()),
+
+    // 문제 조회 관련
+    PROBLEM_LIST_GET_SUCCESS("문제 목록 조회에 성공했습니다.", HttpStatus.OK.value()),
+    PROBLEM_STATISTICS_GET_SUCCESS("문제 통계 조회에 성공했습니다.", HttpStatus.OK.value());
+
+    private final String message;
+    private final int statusCode;
+}

--- a/src/main/java/site/codemonster/comon/domain/problem/dto/response/LeetcodeAPIResponse.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/dto/response/LeetcodeAPIResponse.java
@@ -1,38 +1,48 @@
 package site.codemonster.comon.domain.problem.dto.response;
 
 import java.util.List;
-import java.util.Map;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class LeetcodeAPIResponse {
-    private Map<String, Object> data;
+    private Data data;
 
-    @SuppressWarnings("unchecked")
-    public Map<String, Object> getQuestion() {
-        if (data == null) return null;
-        return (Map<String, Object>) data.get("question");
+    @lombok.Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Data {
+        private Question question;
+    }
+
+    @lombok.Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Question {
+        private String title;
+        private String difficulty;
+        private List<TopicTag> topicTags;
+    }
+
+    @lombok.Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TopicTag {
+        private String name;
     }
 
     public String getTitle() {
-        Map<String, Object> question = getQuestion();
-        return question != null ? (String) question.get("title") : null;
+        return (data != null && data.question != null) ? data.question.title : null;
     }
 
     public String getDifficulty() {
-        Map<String, Object> question = getQuestion();
-        return question != null ? (String) question.get("difficulty") : null;
+        return (data != null && data.question != null) ? data.question.difficulty : null;
     }
 
-    @SuppressWarnings("unchecked")
-    public List<Map<String, Object>> getTopicTags() {
-        Map<String, Object> question = getQuestion();
-        return question != null ? (List<Map<String, Object>>) question.get("topicTags") : null;
+    public List<TopicTag> getTopicTags() {
+        return (data != null && data.question != null) ? data.question.topicTags : null;
     }
 }

--- a/src/main/java/site/codemonster/comon/domain/problem/dto/response/LeetcodeAPIResponse.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/dto/response/LeetcodeAPIResponse.java
@@ -1,0 +1,38 @@
+package site.codemonster.comon.domain.problem.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeetcodeAPIResponse {
+    private Map<String, Object> data;
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getQuestion() {
+        if (data == null) return null;
+        return (Map<String, Object>) data.get("question");
+    }
+
+    public String getTitle() {
+        Map<String, Object> question = getQuestion();
+        return question != null ? (String) question.get("title") : null;
+    }
+
+    public String getDifficulty() {
+        Map<String, Object> question = getQuestion();
+        return question != null ? (String) question.get("difficulty") : null;
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> getTopicTags() {
+        Map<String, Object> question = getQuestion();
+        return question != null ? (List<Map<String, Object>>) question.get("topicTags") : null;
+    }
+}

--- a/src/main/java/site/codemonster/comon/domain/problem/dto/response/LeetcodeAPIResponse.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/dto/response/LeetcodeAPIResponse.java
@@ -1,5 +1,6 @@
 package site.codemonster.comon.domain.problem.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -21,6 +22,7 @@ public class LeetcodeAPIResponse {
     @lombok.Data
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Question {
         private String title;
         private String difficulty;

--- a/src/main/java/site/codemonster/comon/domain/problem/enums/LeetcodeQueryType.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/enums/LeetcodeQueryType.java
@@ -1,0 +1,31 @@
+package site.codemonster.comon.domain.problem.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LeetcodeQueryType {
+
+    PROBLEM_DETAIL("""
+        {
+            question(titleSlug: "%s") {
+                questionId
+                title
+                titleSlug
+                difficulty
+                topicTags {
+                    name
+                }
+                content
+                stats
+            }
+        }
+        """);
+
+    private final String queryTemplate;
+
+    public String formatQuery(String slug) {
+        return String.format(queryTemplate, slug);
+    }
+}

--- a/src/main/java/site/codemonster/comon/domain/problem/service/ProblemCommandService.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/service/ProblemCommandService.java
@@ -95,10 +95,6 @@ public class ProblemCommandService {
     private ProblemInfoResponse collectProblemInfo(String problemInput, Platform platform) {
         ProblemCollector collector = collectorFactory.getCollector(platform);
 
-        if (collector.isValidProblemId(problemInput)) {
-            throw new ProblemInvalidInputException();
-        }
-
         ProblemInfoRequest collectorRequest = ProblemInfoRequest.builder()
                 .platform(platform)
                 .platformProblemId(problemInput)
@@ -114,7 +110,7 @@ public class ProblemCommandService {
     private ProblemInfoResponse collectProblemInfoFromRequest(ProblemInfoRequest request) {
         ProblemCollector collector = collectorFactory.getCollector(request.getPlatform());
 
-        if (collector.isValidProblemId(request.getPlatformProblemId())) {
+        if (!collector.isValidProblemId(request.getPlatformProblemId())) {
             throw new ProblemInvalidInputException();
         }
 

--- a/src/main/java/site/codemonster/comon/domain/problem/service/ProblemCommandService.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/service/ProblemCommandService.java
@@ -54,23 +54,8 @@ public class ProblemCommandService {
         List<Problem> savedProblems = new ArrayList<>();
 
         for (ProblemInfoRequest request : requests) {
-            if (problemQueryService.checkDuplicateProblem(request.getPlatform(), request.getPlatformProblemId())) {
-                continue;
-            }
-
             Problem savedProblem = saveProblem(request);
             savedProblems.add(savedProblem);
-
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new ProblemBatchRegisterException(PROBLEM_REGISTER_INTERRUPTED_ERROR);
-            }
-        }
-
-        if (savedProblems.isEmpty()) {
-            throw new ProblemBatchRegisterException(PROBLEM_ALL_DUPLICATED_ERROR);
         }
 
         return savedProblems;

--- a/src/main/java/site/codemonster/comon/domain/problem/service/ProblemCommandService.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/service/ProblemCommandService.java
@@ -3,7 +3,6 @@ package site.codemonster.comon.domain.problem.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import site.codemonster.comon.domain.problem.collector.LeetcodeCollector;
 import site.codemonster.comon.domain.problem.collector.ProblemCollector;
 import site.codemonster.comon.domain.problem.collector.ProblemCollectorFactory;
 import site.codemonster.comon.domain.problem.dto.request.ProblemInfoRequest;
@@ -26,17 +25,14 @@ public class ProblemCommandService {
 
     private final ProblemRepository problemRepository;
     private final ProblemCollectorFactory collectorFactory;
-    private final LeetcodeCollector leetcodeCollector;
     private final ProblemQueryService problemQueryService;
 
-    public ProblemInfoResponse checkProblem(String problemInput, Platform platform) {
-        String problemId = extractProblemId(problemInput, platform);
-
+    public ProblemInfoResponse checkProblem(String problemId, Platform platform) {
         if (problemQueryService.checkDuplicateProblem(platform, problemId)) {
-            return createDuplicateResponse(platform, problemId, problemInput);
+            return createDuplicateResponse(platform, problemId, problemId);
         }
 
-        return collectProblemInfo(problemInput, platform);
+        return collectProblemInfo(problemId, platform);
     }
 
     public ProblemInfoResponse checkProblem(ProblemInfoRequest request) {
@@ -94,13 +90,6 @@ public class ProblemCommandService {
     public void deleteProblem(Long problemId) {
         Problem problem = problemQueryService.findProblemById(problemId);
         problemRepository.delete(problem);
-    }
-
-    private String extractProblemId(String problemInput, Platform platform) {
-        if (platform == Platform.LEETCODE) {
-            return leetcodeCollector.extractSlugFromUrl(problemInput, true);
-        }
-        return problemInput;
     }
 
     private ProblemInfoResponse collectProblemInfo(String problemInput, Platform platform) {

--- a/src/main/java/site/codemonster/comon/domain/problem/service/ProblemCommandService.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/service/ProblemCommandService.java
@@ -95,7 +95,7 @@ public class ProblemCommandService {
     private ProblemInfoResponse collectProblemInfo(String problemInput, Platform platform) {
         ProblemCollector collector = collectorFactory.getCollector(platform);
 
-        if (!collector.isValidProblem(problemInput)) {
+        if (collector.isValidProblemId(problemInput)) {
             throw new ProblemInvalidInputException();
         }
 
@@ -114,7 +114,7 @@ public class ProblemCommandService {
     private ProblemInfoResponse collectProblemInfoFromRequest(ProblemInfoRequest request) {
         ProblemCollector collector = collectorFactory.getCollector(request.getPlatform());
 
-        if (!collector.isValidProblem(request.getPlatformProblemId())) {
+        if (collector.isValidProblemId(request.getPlatformProblemId())) {
             throw new ProblemInvalidInputException();
         }
 

--- a/src/main/java/site/codemonster/comon/domain/problem/service/ProblemCommandService.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/service/ProblemCommandService.java
@@ -110,7 +110,7 @@ public class ProblemCommandService {
     private ProblemInfoResponse collectProblemInfoFromRequest(ProblemInfoRequest request) {
         ProblemCollector collector = collectorFactory.getCollector(request.getPlatform());
 
-        if (!collector.isValidProblemId(request.getPlatformProblemId())) {
+        if (!collector.isValidProblem(request.getPlatformProblemId())) {
             throw new ProblemInvalidInputException();
         }
 

--- a/src/main/java/site/codemonster/comon/domain/problem/service/ProblemQueryService.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/service/ProblemQueryService.java
@@ -8,12 +8,9 @@ import site.codemonster.comon.domain.problem.entity.Problem;
 import site.codemonster.comon.domain.problem.enums.Platform;
 import site.codemonster.comon.domain.problem.repository.ProblemRepository;
 import site.codemonster.comon.global.error.problem.ProblemNotFoundException;
-import site.codemonster.comon.global.error.problem.ProblemValidationException;
 
 import java.util.List;
 import java.util.Map;
-
-import static site.codemonster.comon.global.error.ErrorCode.PROBLEM_PLATFORM_REQUIRED_ERROR;
 
 @Service
 @RequiredArgsConstructor
@@ -39,9 +36,6 @@ public class ProblemQueryService {
     }
 
     public List<Problem> getProblemsByPlatform(Platform platform) {
-        if (platform == null) {
-            throw new ProblemValidationException(PROBLEM_PLATFORM_REQUIRED_ERROR);
-        }
         return problemRepository.findByPlatform(platform);
     }
 

--- a/src/main/java/site/codemonster/comon/domain/problem/service/ProblemQueryService.java
+++ b/src/main/java/site/codemonster/comon/domain/problem/service/ProblemQueryService.java
@@ -1,0 +1,52 @@
+package site.codemonster.comon.domain.problem.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.codemonster.comon.domain.problem.entity.Problem;
+import site.codemonster.comon.domain.problem.enums.Platform;
+import site.codemonster.comon.domain.problem.repository.ProblemRepository;
+import site.codemonster.comon.global.error.problem.ProblemNotFoundException;
+import site.codemonster.comon.global.error.problem.ProblemValidationException;
+
+import java.util.List;
+import java.util.Map;
+
+import static site.codemonster.comon.global.error.ErrorCode.PROBLEM_PLATFORM_REQUIRED_ERROR;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemQueryService {
+
+    private final ProblemRepository problemRepository;
+
+    public boolean checkDuplicateProblem(Platform platform, String problemId) {
+        return problemRepository.existsByPlatformAndPlatformProblemId(platform, problemId);
+    }
+
+    public Map<Platform, Long> getProblemStatistics() {
+        return Map.of(
+                Platform.BAEKJOON, problemRepository.countByPlatform(Platform.BAEKJOON),
+                Platform.LEETCODE, problemRepository.countByPlatform(Platform.LEETCODE),
+                Platform.PROGRAMMERS, problemRepository.countByPlatform(Platform.PROGRAMMERS)
+        );
+    }
+
+    public List<Problem> getAllProblems() {
+        return problemRepository.findAll(Sort.by(Sort.Direction.DESC, "createdDate"));
+    }
+
+    public List<Problem> getProblemsByPlatform(Platform platform) {
+        if (platform == null) {
+            throw new ProblemValidationException(PROBLEM_PLATFORM_REQUIRED_ERROR);
+        }
+        return problemRepository.findByPlatform(platform);
+    }
+
+    public Problem findProblemById(Long problemId) {
+        return problemRepository.findById(problemId)
+                .orElseThrow(ProblemNotFoundException::new);
+    }
+}

--- a/src/main/java/site/codemonster/comon/domain/recommendation/service/TeamRecommendationService.java
+++ b/src/main/java/site/codemonster/comon/domain/recommendation/service/TeamRecommendationService.java
@@ -11,7 +11,7 @@ import site.codemonster.comon.domain.auth.entity.Member;
 import site.codemonster.comon.domain.auth.service.MemberService;
 import site.codemonster.comon.domain.problem.entity.Problem;
 import site.codemonster.comon.domain.problem.enums.Platform;
-import site.codemonster.comon.domain.problem.service.ProblemService;
+import site.codemonster.comon.domain.problem.service.ProblemQueryService;
 import site.codemonster.comon.domain.recommendation.dto.request.ManualRecommendationRequest;
 import site.codemonster.comon.domain.recommendation.dto.request.TeamRecommendationRequest;
 import site.codemonster.comon.domain.recommendation.dto.response.ManualRecommendationResponse;
@@ -41,7 +41,7 @@ public class TeamRecommendationService {
     private final TeamRecommendationRepository teamRecommendationRepository;
     private final PlatformRecommendationService platformRecommendationService;
     private final MemberService memberService;
-    private final ProblemService problemService;
+    private final ProblemQueryService problemQueryService;
     private final ObjectMapper objectMapper;
     private final ConvertUtils convertUtils;
 
@@ -158,7 +158,7 @@ public class TeamRecommendationService {
     private List<Problem> recommendProblemsByPlatform(Team team, Platform platform, int count,
                                                       List<String> difficulties, List<String> tags) {
         Set<Long> recommendedProblemIds = recommendationHistoryService.getRecommendedProblemIds(team, platform);
-        List<Problem> allProblemsForPlatform = problemService.getProblemsByPlatform(platform);
+        List<Problem> allProblemsForPlatform = problemQueryService.getProblemsByPlatform(platform);
 
         List<Problem> availableProblems = allProblemsForPlatform.stream()
                 .filter(p -> !recommendedProblemIds.contains(p.getProblemId()))

--- a/src/main/java/site/codemonster/comon/global/error/ErrorCode.java
+++ b/src/main/java/site/codemonster/comon/global/error/ErrorCode.java
@@ -63,7 +63,6 @@ public enum ErrorCode {
     PROBLEM_COLLECTION_ERROR(HttpStatus.BAD_REQUEST, 400, "문제 정보를 수집할 수 없습니다."),
     PROBLEM_UPDATE_DATA_EMPTY_ERROR(HttpStatus.BAD_REQUEST, 400, "수정할 데이터가 없습니다."),
     PROBLEM_BATCH_REGISTER_EMPTY_ERROR(HttpStatus.BAD_REQUEST, 400, "등록할 문제 목록이 비어있습니다."),
-    PROBLEM_ALL_DUPLICATED_ERROR(HttpStatus.BAD_REQUEST, 400, "모든 문제가 이미 등록되어 있습니다."),
     PROBLEM_REGISTER_INTERRUPTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "문제 등록 중 인터럽트가 발생했습니다."),
     PROBLEM_PLATFORM_REQUIRED_ERROR(HttpStatus.BAD_REQUEST, 400, "플랫폼 정보가 필요합니다."),
     PROBLEM_TITLE_REQUIRED_ERROR(HttpStatus.BAD_REQUEST, 400, "문제 제목이 필요합니다."),

--- a/src/main/java/site/codemonster/comon/global/error/ErrorCode.java
+++ b/src/main/java/site/codemonster/comon/global/error/ErrorCode.java
@@ -55,7 +55,20 @@ public enum ErrorCode {
     DATETIME_PARSE_ERROR(HttpStatus.BAD_REQUEST, 400,"날짜 및 날짜 형식이 올바르지 않습니다."),
 
     // TEAM_RECOMMENDATION
-    TEAM_RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "팀의 추천 설정이 존재하지 않습니다.");
+    TEAM_RECOMMENDATION_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "팀의 추천 설정이 존재하지 않습니다."),
+
+    // PROBLEM
+    PROBLEM_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, 404, "문제를 찾을 수 없습니다."),
+    PROBLEM_INVALID_INPUT_ERROR(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 문제 정보입니다."),
+    PROBLEM_COLLECTION_ERROR(HttpStatus.BAD_REQUEST, 400, "문제 정보를 수집할 수 없습니다."),
+    PROBLEM_UPDATE_DATA_EMPTY_ERROR(HttpStatus.BAD_REQUEST, 400, "수정할 데이터가 없습니다."),
+    PROBLEM_BATCH_REGISTER_EMPTY_ERROR(HttpStatus.BAD_REQUEST, 400, "등록할 문제 목록이 비어있습니다."),
+    PROBLEM_ALL_DUPLICATED_ERROR(HttpStatus.BAD_REQUEST, 400, "모든 문제가 이미 등록되어 있습니다."),
+    PROBLEM_REGISTER_INTERRUPTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "문제 등록 중 인터럽트가 발생했습니다."),
+    PROBLEM_PLATFORM_REQUIRED_ERROR(HttpStatus.BAD_REQUEST, 400, "플랫폼 정보가 필요합니다."),
+    PROBLEM_TITLE_REQUIRED_ERROR(HttpStatus.BAD_REQUEST, 400, "문제 제목이 필요합니다."),
+    PROBLEM_ID_REQUIRED_ERROR(HttpStatus.BAD_REQUEST, 400, "문제 ID가 필요합니다."),
+    PROBLEM_UNSUPPORTED_FIELD_ERROR(HttpStatus.BAD_REQUEST, 400, "지원하지 않는 필드입니다.");
 
     private final HttpStatus status;
     private final int customStatusCode;

--- a/src/main/java/site/codemonster/comon/global/error/ErrorCode.java
+++ b/src/main/java/site/codemonster/comon/global/error/ErrorCode.java
@@ -68,7 +68,12 @@ public enum ErrorCode {
     PROBLEM_PLATFORM_REQUIRED_ERROR(HttpStatus.BAD_REQUEST, 400, "플랫폼 정보가 필요합니다."),
     PROBLEM_TITLE_REQUIRED_ERROR(HttpStatus.BAD_REQUEST, 400, "문제 제목이 필요합니다."),
     PROBLEM_ID_REQUIRED_ERROR(HttpStatus.BAD_REQUEST, 400, "문제 ID가 필요합니다."),
-    PROBLEM_UNSUPPORTED_FIELD_ERROR(HttpStatus.BAD_REQUEST, 400, "지원하지 않는 필드입니다.");
+    PROBLEM_UNSUPPORTED_FIELD_ERROR(HttpStatus.BAD_REQUEST, 400, "지원하지 않는 필드입니다."),
+    PROBLEM_DIFFICULTY_REQUIRED_ERROR(HttpStatus.BAD_REQUEST, 400, "난이도를 선택해주세요."),
+    PROBLEM_DIFFICULTY_INVALID_ERROR(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 난이도입니다."),
+    PROBLEM_TITLE_TOO_LONG_ERROR(HttpStatus.BAD_REQUEST, 400, "제목이 너무 깁니다. (최대 50자)"),
+    PROBLEM_TAGS_TOO_LONG_ERROR(HttpStatus.BAD_REQUEST, 400, "태그가 너무 깁니다. (최대 50자)"),
+    PROBLEM_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, 400, "문제 정보 검증에 실패했습니다.");
 
     private final HttpStatus status;
     private final int customStatusCode;

--- a/src/main/java/site/codemonster/comon/global/error/problem/ProblemBatchRegisterException.java
+++ b/src/main/java/site/codemonster/comon/global/error/problem/ProblemBatchRegisterException.java
@@ -1,0 +1,10 @@
+package site.codemonster.comon.global.error.problem;
+
+import site.codemonster.comon.global.error.ComonException;
+import site.codemonster.comon.global.error.ErrorCode;
+
+public class ProblemBatchRegisterException extends ComonException {
+    public ProblemBatchRegisterException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/site/codemonster/comon/global/error/problem/ProblemCollectionException.java
+++ b/src/main/java/site/codemonster/comon/global/error/problem/ProblemCollectionException.java
@@ -1,0 +1,10 @@
+package site.codemonster.comon.global.error.problem;
+
+import site.codemonster.comon.global.error.ComonException;
+import site.codemonster.comon.global.error.ErrorCode;
+
+public class ProblemCollectionException extends ComonException {
+    public ProblemCollectionException() {
+        super(ErrorCode.PROBLEM_COLLECTION_ERROR);
+    }
+}

--- a/src/main/java/site/codemonster/comon/global/error/problem/ProblemInvalidInputException.java
+++ b/src/main/java/site/codemonster/comon/global/error/problem/ProblemInvalidInputException.java
@@ -1,0 +1,10 @@
+package site.codemonster.comon.global.error.problem;
+
+import site.codemonster.comon.global.error.ComonException;
+import site.codemonster.comon.global.error.ErrorCode;
+
+public class ProblemInvalidInputException extends ComonException {
+    public ProblemInvalidInputException() {
+        super(ErrorCode.PROBLEM_INVALID_INPUT_ERROR);
+    }
+}

--- a/src/main/java/site/codemonster/comon/global/error/problem/ProblemNotFoundException.java
+++ b/src/main/java/site/codemonster/comon/global/error/problem/ProblemNotFoundException.java
@@ -1,0 +1,10 @@
+package site.codemonster.comon.global.error.problem;
+
+import site.codemonster.comon.global.error.ComonException;
+import site.codemonster.comon.global.error.ErrorCode;
+
+public class ProblemNotFoundException extends ComonException {
+    public ProblemNotFoundException() {
+        super(ErrorCode.PROBLEM_NOT_FOUND_ERROR);
+    }
+}

--- a/src/main/java/site/codemonster/comon/global/error/problem/ProblemValidationException.java
+++ b/src/main/java/site/codemonster/comon/global/error/problem/ProblemValidationException.java
@@ -1,0 +1,10 @@
+package site.codemonster.comon.global.error.problem;
+
+import site.codemonster.comon.global.error.ComonException;
+import site.codemonster.comon.global.error.ErrorCode;
+
+public class ProblemValidationException extends ComonException {
+    public ProblemValidationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/site/codemonster/comon/global/globalConfig/RestClientConfig.java
+++ b/src/main/java/site/codemonster/comon/global/globalConfig/RestClientConfig.java
@@ -2,13 +2,12 @@ package site.codemonster.comon.global.globalConfig;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 
 @Configuration
-public class RestTemplateConfig {
-
+public class RestClientConfig {
     @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
+    public RestClient restClient() {
+        return RestClient.create();
     }
 }

--- a/src/main/java/site/codemonster/comon/global/security/configuration/AdminWebConfig.java
+++ b/src/main/java/site/codemonster/comon/global/security/configuration/AdminWebConfig.java
@@ -28,7 +28,7 @@ public class AdminWebConfig implements WebMvcConfigurer {
                         "/admin/images/**",
 
                         // API
-                        "/admin/problems/api/**"
+                        "/admin/problems/**"
                 )
                 .order(0);
     }

--- a/src/main/resources/static/admin/js/problem-list.js
+++ b/src/main/resources/static/admin/js/problem-list.js
@@ -94,7 +94,7 @@ function loadProblems() {
     showLoading();
 
     // 실제 API 호출
-    fetch('/admin/problems/api/list')
+    fetch('/admin/problems/problem-list')
         .then(response => {
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
@@ -574,7 +574,7 @@ function saveProblem() {
     };
 
     // API 호출
-    fetch(`/admin/problems/api/${problemId}`, {
+    fetch(`/admin/problems/${problemId}`, {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json'
@@ -624,7 +624,7 @@ function deleteProblem(problemId) {
     }
 
     // API 호출
-    fetch(`/admin/problems/api/${problemId}`, {
+    fetch(`/admin/problems/${problemId}`, {
         method: 'DELETE'
     })
         .then(response => {

--- a/src/main/resources/static/admin/js/problem-list.js
+++ b/src/main/resources/static/admin/js/problem-list.js
@@ -103,10 +103,14 @@ function loadProblems() {
         })
         .then(data => {
             console.log('문제 목록 로드 성공:', data);
-            allProblems = data;
-            initializeFilters();
-            applyFilters();
-            hideLoading();
+            if (data.status === 'success') {
+                allProblems = data.data || [];
+                initializeFilters();
+                applyFilters();
+                hideLoading();
+            } else {
+                throw new Error(data.message || '문제 목록을 불러올 수 없습니다');
+            }
         })
         .catch(error => {
             console.error('문제 목록 로드 실패:', error);
@@ -584,19 +588,23 @@ function saveProblem() {
             return response.json();
         })
         .then(data => {
-            alert('문제가 성공적으로 수정되었습니다.');
+            if (data.status === 'success') {
+                alert('문제가 성공적으로 수정되었습니다.');
 
-            // 로컬 데이터 업데이트
-            const problemIndex = allProblems.findIndex(p => p.problemId == problemId);
-            if (problemIndex !== -1) {
-                allProblems[problemIndex] = { ...allProblems[problemIndex], ...updateData };
+                // 로컬 데이터 업데이트 - data.data가 수정된 Problem 엔티티
+                const problemIndex = allProblems.findIndex(p => p.problemId == problemId);
+                if (problemIndex !== -1) {
+                    allProblems[problemIndex] = { ...allProblems[problemIndex], ...updateData };
+                }
+
+                // 필터 다시 적용
+                applyFilters();
+
+                // 모달 닫기
+                bootstrap.Modal.getInstance(document.getElementById('editModal')).hide();
+            } else {
+                alert('문제 수정에 실패했습니다: ' + (data.message || '알 수 없는 오류'));
             }
-
-            // 필터 다시 적용
-            applyFilters();
-
-            // 모달 닫기
-            bootstrap.Modal.getInstance(document.getElementById('editModal')).hide();
         })
         .catch(error => {
             console.error('문제 수정 실패:', error);
@@ -626,13 +634,17 @@ function deleteProblem(problemId) {
             return response.json();
         })
         .then(data => {
-            alert('문제가 성공적으로 삭제되었습니다.');
+            if (data.status === 'success') {
+                alert('문제가 성공적으로 삭제되었습니다.');
 
-            // 로컬 데이터에서 제거
-            allProblems = allProblems.filter(p => p.problemId != problemId);
+                // 로컬 데이터에서 제거
+                allProblems = allProblems.filter(p => p.problemId != problemId);
 
-            // 필터 다시 적용
-            applyFilters();
+                // 필터 다시 적용
+                applyFilters();
+            } else {
+                alert('문제 삭제에 실패했습니다: ' + (data.message || '알 수 없는 오류'));
+            }
         })
         .catch(error => {
             console.error('문제 삭제 실패:', error);

--- a/src/main/resources/static/admin/js/problem-recommendation.js
+++ b/src/main/resources/static/admin/js/problem-recommendation.js
@@ -404,7 +404,12 @@ function loadPlatformData(platform) {
         })
         .then(data => {
             console.log(`${platform} 플랫폼 데이터 로드 성공:`, data);
-            populatePlatformOptions(platform, data);
+            if (data.status === 'success') {
+                populatePlatformOptions(platform, data.data || []);
+            } else {
+                console.error(`${platform} 옵션 로드 실패:`, data.message);
+                populateDefaultOptions(platform);
+            }
         })
         .catch(error => {
             console.error(`${platform} 옵션 로드 실패:`, error);
@@ -724,7 +729,7 @@ function executeManualRecommendation() {
         .then(data => {
             hideLoading();
             if (data.status === 'success') {
-                alert(`${data.data.message}`);
+                alert(`${data.data.message || '수동 추천이 완료되었습니다'}`);
                 // 선택된 날짜들 초기화
                 selectedDates = [];
                 updateSelectedDatesDisplay();
@@ -884,7 +889,7 @@ function resetCurrentSettings() {
         })
         .then(data => {
             hideLoading();
-            if (data.success) {
+            if (data.status === 'success') {
                 alert('설정이 초기화되었습니다.');
                 resetUISettings(); // UI 초기화
             } else {

--- a/src/main/resources/static/admin/js/problem-recommendation.js
+++ b/src/main/resources/static/admin/js/problem-recommendation.js
@@ -395,7 +395,7 @@ function loadPlatformOptions() {
 function loadPlatformData(platform) {
     console.log(`${platform} 플랫폼 데이터 로드 중...`);
 
-    return fetch(`/admin/problems/api/list-by-platform?platform=${platform}`)
+    return fetch(`/admin/problems/list-by-platform?platform=${platform}`)
         .then(response => {
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/main/resources/static/admin/js/problem-register.js
+++ b/src/main/resources/static/admin/js/problem-register.js
@@ -183,18 +183,7 @@ function checkProgrammers() {
         })
         .then(data => {
             hideLoading();
-            if (data.success) {
-                if (data.isDuplicate) {
-                    alert(`이미 등록된 문제입니다: ${data.platform} ${data.platformProblemId}`);
-                    clearProgrammersInputs();
-                } else {
-                    addProblemToList(data);
-                    clearProgrammersInputs();
-                    alert('프로그래머스 문제가 성공적으로 추가되었습니다.');
-                }
-            } else {
-                alert('오류: ' + (data.errorMessage || '알 수 없는 오류'));
-            }
+            handleProblemCheckResponse(data, 'programmers-problem-id');
         })
         .catch(error => {
             console.error('프로그래머스 문제 확인 실패:', error);
@@ -235,22 +224,7 @@ function checkLeetcode() {
         })
         .then(data => {
             hideLoading();
-            console.log('리트코드 응답:', data);
-
-            if (data.success) {
-                if (data.isDuplicate) {
-                    // 중복된 문제인 경우
-                    alert(`이미 등록된 문제입니다: ${data.platform} ${data.platformProblemId}`);
-                    document.getElementById('leetcode-url').value = '';
-                } else {
-                    // 새로운 문제인 경우
-                    addProblemToList(data);
-                    document.getElementById('leetcode-url').value = '';
-                    alert(`문제가 성공적으로 추가되었습니다: ${data.title}`);
-                }
-            } else {
-                alert('오류: ' + (data.errorMessage || '알 수 없는 오류'));
-            }
+            handleProblemCheckResponse(data, 'leetcode-url');
         })
         .catch(error => {
             console.error('리트코드 문제 확인 실패:', error);
@@ -263,17 +237,17 @@ function checkLeetcode() {
  * 문제 확인 응답 처리 (공통 함수)
  */
 function handleProblemCheckResponse(data, inputId) {
-    if (data.success) {
-        if (data.isDuplicate) {
-            alert(`이미 등록된 문제입니다: ${data.platform} ${data.platformProblemId}`);
+    if (data.status === 'success') {
+        if (data.data.isDuplicate === true || data.data.title === '(중복된 문제)') {
+            alert(`이미 등록된 문제입니다: ${data.data.platform} ${data.data.platformProblemId}`);
             document.getElementById(inputId).value = '';
         } else {
-            addProblemToList(data);
+            addProblemToList(data.data);
             document.getElementById(inputId).value = '';
-            alert(`문제가 성공적으로 추가되었습니다: ${data.title}`);
+            alert(`문제가 성공적으로 추가되었습니다: ${data.data.title}`);
         }
     } else {
-        alert('오류: ' + (data.errorMessage || '알 수 없는 오류'));
+        alert('오류: ' + (data.message || '알 수 없는 오류'));
     }
 }
 
@@ -283,6 +257,9 @@ function handleProblemCheckResponse(data, inputId) {
  * 문제 목록에 추가
  */
 function addProblemToList(problemData) {
+    console.log('addProblemToList 호출됨, 받은 데이터:', problemData);
+    console.log('isDuplicate 값:', problemData.isDuplicate);
+
     // 서버에서 중복으로 표시된 문제는 추가하지 않음
     if (problemData.isDuplicate) {
         console.log('중복된 문제이므로 목록에 추가하지 않습니다:', problemData);
@@ -443,8 +420,8 @@ function registerAllProblems() {
             hideLoading();
             console.log('등록 결과:', data);
 
-            if (data.success) {
-                alert(`${data.count || validProblems.length}개 문제가 성공적으로 등록되었습니다!`);
+            if (data.status === 'success') {
+                alert(`${data.data.count || validProblems.length}개 문제가 성공적으로 등록되었습니다!`);
                 // 성공시 목록 비우기
                 problemList = [];
                 problemIdCounter = 0;

--- a/src/main/resources/static/admin/js/problem-register.js
+++ b/src/main/resources/static/admin/js/problem-register.js
@@ -129,7 +129,7 @@ function checkBaekjoon() {
     console.log('백준 문제 확인:', problemId);
     showLoading('백준 문제 정보를 가져오는 중...');
 
-    fetch('/admin/problems/check/baekjoon', {
+    fetch('/admin/problems/get/baekjoon', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: 'problemId=' + encodeURIComponent(problemId)
@@ -170,7 +170,7 @@ function checkProgrammers() {
     console.log('프로그래머스 문제 확인:', data);
     showLoading('프로그래머스 문제를 처리하는 중...');
 
-    fetch('/admin/problems/check/programmers', {
+    fetch('/admin/problems/get/programmers', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)
@@ -211,7 +211,7 @@ function checkLeetcode() {
     console.log('리트코드 문제 확인:', url);
     showLoading('리트코드 문제 정보를 가져오는 중...');
 
-    fetch('/admin/problems/check/leetcode', {
+    fetch('/admin/problems/get/leetcode', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: `url=${encodeURIComponent(url)}`
@@ -405,7 +405,7 @@ function registerAllProblems() {
         registerBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>등록 중...';
     }
 
-    fetch('/admin/problems/register/batch', {
+    fetch('/admin/problems/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestData)


### PR DESCRIPTION
## 🔥 관련 이슈

- close: #17 

---

## 📝 작업 상세 설명
### 1. 컨트롤러 응답 구조 개선
 기존 다른 코드들을 보시면 아시다시피 `ApiResponse`를 적극 활용합니다! 이를 적용하였습니다!

### 2. 예외 처리 표준화
 마찬가지로 코드를 보면 아시다시피 예외처리를 `GlobalExceptionHandler`를 이용하여 특정 exception을 throw했을 때 그에 맞는 `CustomException`이 throw되도록 합니다. 

 위 2가지 내용은 저희 서비스에서 반환값을 다루는 정말 중요한 규칙이기에 꼭 숙지해야할 거 같아욤-!

### 3. 서비스 계층 분리 
 `ProblemService` 코드가 너무 길어서.. 조회 기능을 담당하는 기능들은 `ProblemQueryService`로, 그외의 기능들은 `ProblemCommandService`에서 관리하도록 분리해주었습니다! 이를 CQRS 패턴이라고 하더라구요!

### 4. 리트코드 GraphQL 쿼리 관리 개선
 리트코드 GraphQL 쿼리의 경우 AI 관련 api부르듯이 쿼리가 있기에 이를 따로 ENUM으로 관리해주었습니다!

---

## ⭐ 리뷰 포인트
 처음에 최대한 이쁘게 잘 짜는게 중요한 거 같습니다 ㅠ.ㅠ 리뷰 잘 부탁드려요-!

