### PR TITLE
fix: 팀 삭제 관련 문제 해결

### DIFF
--- a/src/main/java/site/codemonster/comon/domain/article/entity/ArticleImage.java
+++ b/src/main/java/site/codemonster/comon/domain/article/entity/ArticleImage.java
@@ -12,6 +12,7 @@ public class ArticleImage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long articleImageId;
 
+    @Column(columnDefinition = "TEXT")
     private String imageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/site/codemonster/comon/domain/article/service/ArticleLowService.java
+++ b/src/main/java/site/codemonster/comon/domain/article/service/ArticleLowService.java
@@ -91,7 +91,7 @@ public class ArticleLowService {
         return articleRepository.existsByTeamAndSelectedDateAndArticleCategoryIn(team, selectedDate, subjectCategories);
     }
 
-    public void deleteByTeamTeamId(Long teamId) {
+    public void deleteByTeamId(Long teamId) {
 
         List<Long> deletedIds = articleRepository.findByTeamId(teamId)
                 .stream().map(Article::getArticleId).toList();

--- a/src/main/java/site/codemonster/comon/domain/auth/entity/Member.java
+++ b/src/main/java/site/codemonster/comon/domain/auth/entity/Member.java
@@ -30,6 +30,7 @@ public class Member extends TimeStamp {
 
     private String memberName;
 
+    @Column(columnDefinition = "TEXT")
     private String imageUrl = ImageConstant.DEFAULT_MEMBER_PROFILE.getObjectKey();
 
     private String description;

--- a/src/main/java/site/codemonster/comon/domain/auth/service/MemberService.java
+++ b/src/main/java/site/codemonster/comon/domain/auth/service/MemberService.java
@@ -78,7 +78,7 @@ public class MemberService {
         teamRecruitLowService.deleteByMemberId(memberId);
         teamApplyLowService.deleteTeamAppliesByMemberId(memberId);
 
-        List<Team> teamsManagedByMember = teamLowService.findByTeamMangerId(memberId);
+        List<Team> teamsManagedByMember = teamLowService.findByTeamManagerId(memberId);
 
         for (Team team : teamsManagedByMember) {
             Long teamId = team.getTeamId();

--- a/src/main/java/site/codemonster/comon/domain/auth/service/MemberService.java
+++ b/src/main/java/site/codemonster/comon/domain/auth/service/MemberService.java
@@ -78,9 +78,14 @@ public class MemberService {
         teamRecruitLowService.deleteByMemberId(memberId);
         teamApplyLowService.deleteTeamAppliesByMemberId(memberId);
 
-        List<Team> teamsManagedByMember = teamLowService.findByTeamMangerIdForDelete(memberId);
+        List<Team> teamsManagedByMember = teamLowService.findByTeamMangerId(memberId);
+
         for (Team team : teamsManagedByMember) {
             Long teamId = team.getTeamId();
+
+            List<TeamMember> teamManagers = teamMemberLowService.findTeamManagerByTeamIdForUpdate(teamId);
+
+            if (teamManagers.size() > 1) continue;
 
             articleLowService.deleteByTeamId(teamId);
 

--- a/src/main/java/site/codemonster/comon/domain/auth/service/MemberService.java
+++ b/src/main/java/site/codemonster/comon/domain/auth/service/MemberService.java
@@ -78,7 +78,7 @@ public class MemberService {
         teamRecruitLowService.deleteByMemberId(memberId);
         teamApplyLowService.deleteTeamAppliesByMemberId(memberId);
 
-        List<Team> teamsManagedByMember = teamLowService.findByTeamManagerId(memberId);
+        List<Team> teamsManagedByMember = teamLowService.findByTeamMangerIdForDelete(memberId);
         for (Team team : teamsManagedByMember) {
             Long teamId = team.getTeamId();
 

--- a/src/main/java/site/codemonster/comon/domain/auth/service/MemberService.java
+++ b/src/main/java/site/codemonster/comon/domain/auth/service/MemberService.java
@@ -82,9 +82,7 @@ public class MemberService {
         for (Team team : teamsManagedByMember) {
             Long teamId = team.getTeamId();
 
-            articleLowService.deleteByTeamTeamId(teamId);
-
-            teamMemberLowService.deleteByTeamTeamId(teamId);
+            articleLowService.deleteByTeamId(teamId);
 
             teamLowService.deleteById(teamId);
         }

--- a/src/main/java/site/codemonster/comon/domain/recommendation/repository/TeamRecommendationRepository.java
+++ b/src/main/java/site/codemonster/comon/domain/recommendation/repository/TeamRecommendationRepository.java
@@ -13,6 +13,9 @@ public interface TeamRecommendationRepository extends JpaRepository<TeamRecommen
 
     Optional<TeamRecommendation> findByTeam(Team team);
 
+    @Query("select tr from TeamRecommendation tr where tr.team.teamId = :teamId")
+    Optional<TeamRecommendation> findByTeamId(Long teamId);
+
     boolean existsByTeam(Team team);
 
 

--- a/src/main/java/site/codemonster/comon/domain/team/repository/TeamRepository.java
+++ b/src/main/java/site/codemonster/comon/domain/team/repository/TeamRepository.java
@@ -18,14 +18,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     Page<Team> findByTeamNameContaining(String keyword, Pageable pageable);
 
 
-    @Query("""
-    SELECT t
-    FROM Team t
-    join TeamMember tm on tm.team.teamId = t.teamId
-    WHERE tm.member.id = :managerId AND tm.isTeamManager = TRUE
-    """
-    )
-    List<Team> findByTeamMangerId(@Param("managerId") Long mangerId);
 
 
 

--- a/src/main/java/site/codemonster/comon/domain/team/repository/TeamRepository.java
+++ b/src/main/java/site/codemonster/comon/domain/team/repository/TeamRepository.java
@@ -16,6 +16,26 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     Page<Team> findAllWithPagination(Pageable pageable);
 
     Page<Team> findByTeamNameContaining(String keyword, Pageable pageable);
+
+
+    @Query("""
+    SELECT t
+    FROM Team t
+    JOIN TeamMember tm ON t.teamId = tm.team.teamId
+    WHERE tm.member.id = :managerId
+      AND tm.isTeamManager = TRUE
+      AND (
+          SELECT COUNT(tm2)
+          FROM TeamMember tm2
+          WHERE tm2.team = t
+            AND tm2.isTeamManager = TRUE
+      ) = 1
+    """
+    )
+    List<Team> findByTeamMangerIdForDelete(@Param("managerId") Long mangerId);
+
+
+
     @Query("SELECT t FROM Team t "
             + "JOIN TeamMember tm ON t.teamId = tm.team.teamId "
             + "WHERE tm.member.id = :managerId AND tm.isTeamManager = TRUE")

--- a/src/main/java/site/codemonster/comon/domain/team/repository/TeamRepository.java
+++ b/src/main/java/site/codemonster/comon/domain/team/repository/TeamRepository.java
@@ -21,18 +21,11 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     @Query("""
     SELECT t
     FROM Team t
-    JOIN TeamMember tm ON t.teamId = tm.team.teamId
-    WHERE tm.member.id = :managerId
-      AND tm.isTeamManager = TRUE
-      AND (
-          SELECT COUNT(tm2)
-          FROM TeamMember tm2
-          WHERE tm2.team = t
-            AND tm2.isTeamManager = TRUE
-      ) = 1
+    join TeamMember tm on tm.team.teamId = t.teamId
+    WHERE tm.member.id = :managerId AND tm.isTeamManager = TRUE
     """
     )
-    List<Team> findByTeamMangerIdForDelete(@Param("managerId") Long mangerId);
+    List<Team> findByTeamMangerId(@Param("managerId") Long mangerId);
 
 
 

--- a/src/main/java/site/codemonster/comon/domain/team/service/TeamLowService.java
+++ b/src/main/java/site/codemonster/comon/domain/team/service/TeamLowService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import site.codemonster.comon.domain.article.repository.ArticleRepository;
 import site.codemonster.comon.domain.recommendation.entity.RecommendationHistory;
 import site.codemonster.comon.domain.recommendation.entity.TeamRecommendation;
+import site.codemonster.comon.domain.recommendation.repository.PlatformRecommendationRepository;
 import site.codemonster.comon.domain.recommendation.repository.RecommendationHistoryRepository;
 import site.codemonster.comon.domain.recommendation.repository.TeamRecommendationDayRepository;
 import site.codemonster.comon.domain.recommendation.repository.TeamRecommendationRepository;
@@ -30,6 +31,7 @@ public class TeamLowService {
     private final TeamRecommendationDayRepository teamRecommendationDayRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final RecommendationHistoryRepository recommendationHistoryRepository;
+    private final PlatformRecommendationRepository platformRecommendationRepository;
 
     @Transactional(readOnly = true)
     public Team findById(Long id) {
@@ -69,6 +71,7 @@ public class TeamLowService {
 
         if (deleteTeamRecommendation.isPresent()) {
             teamRecommendationDayRepository.deleteByTeamRecommendationId(deleteTeamRecommendation.get().getId());
+            platformRecommendationRepository.deleteByTeamRecommendationId(deleteTeamRecommendation.get().getId());
         }
 
         teamRecommendationRepository.deleteByTeamId(teamId);

--- a/src/main/java/site/codemonster/comon/domain/team/service/TeamLowService.java
+++ b/src/main/java/site/codemonster/comon/domain/team/service/TeamLowService.java
@@ -5,11 +5,19 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.codemonster.comon.domain.article.repository.ArticleRepository;
+import site.codemonster.comon.domain.recommendation.entity.RecommendationHistory;
+import site.codemonster.comon.domain.recommendation.entity.TeamRecommendation;
+import site.codemonster.comon.domain.recommendation.repository.RecommendationHistoryRepository;
+import site.codemonster.comon.domain.recommendation.repository.TeamRecommendationDayRepository;
+import site.codemonster.comon.domain.recommendation.repository.TeamRecommendationRepository;
 import site.codemonster.comon.domain.team.entity.Team;
 import site.codemonster.comon.domain.team.repository.TeamRepository;
+import site.codemonster.comon.domain.teamMember.repository.TeamMemberRepository;
 import site.codemonster.comon.global.error.Team.TeamNotFoundException;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Transactional
@@ -17,6 +25,10 @@ import java.util.List;
 public class TeamLowService {
 
     private final TeamRepository teamRepository;
+    private final TeamRecommendationRepository teamRecommendationRepository;
+    private final TeamRecommendationDayRepository teamRecommendationDayRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final RecommendationHistoryRepository recommendationHistoryRepository;
 
     @Transactional(readOnly = true)
     public Team findById(Long id) {
@@ -51,6 +63,17 @@ public class TeamLowService {
     }
 
     public void deleteById(Long teamId) {
+
+        Optional<TeamRecommendation> deleteTeamRecommendation = teamRecommendationRepository.findByTeamId(teamId);
+
+        if (deleteTeamRecommendation.isPresent()) {
+            teamRecommendationDayRepository.deleteByTeamRecommendationId(deleteTeamRecommendation.get().getId());
+        }
+
+        teamRecommendationRepository.deleteByTeamId(teamId);
+
+        recommendationHistoryRepository.deleteByTeamTeamId(teamId);
+        teamMemberRepository.deleteByTeamTeamId(teamId);
         teamRepository.deleteById(teamId);
     }
 

--- a/src/main/java/site/codemonster/comon/domain/team/service/TeamLowService.java
+++ b/src/main/java/site/codemonster/comon/domain/team/service/TeamLowService.java
@@ -83,10 +83,6 @@ public class TeamLowService {
         return teamRepository.findByTeamManagerId(memberId);
     }
 
-    @Transactional(readOnly = true)
-    public List<Team> findByTeamMangerId(Long memberId) {
-        return teamRepository.findByTeamMangerId(memberId);
-    }
 
     @Transactional(readOnly = true)
     public List<Team> findAll() {

--- a/src/main/java/site/codemonster/comon/domain/team/service/TeamLowService.java
+++ b/src/main/java/site/codemonster/comon/domain/team/service/TeamLowService.java
@@ -13,6 +13,7 @@ import site.codemonster.comon.domain.recommendation.repository.TeamRecommendatio
 import site.codemonster.comon.domain.recommendation.repository.TeamRecommendationRepository;
 import site.codemonster.comon.domain.team.entity.Team;
 import site.codemonster.comon.domain.team.repository.TeamRepository;
+import site.codemonster.comon.domain.teamMember.entity.TeamMember;
 import site.codemonster.comon.domain.teamMember.repository.TeamMemberRepository;
 import site.codemonster.comon.global.error.Team.TeamNotFoundException;
 
@@ -80,6 +81,11 @@ public class TeamLowService {
     @Transactional(readOnly = true)
     public List<Team> findByTeamManagerId(Long memberId) {
         return teamRepository.findByTeamManagerId(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Team> findByTeamMangerIdForDelete(Long memberId) {
+        return teamRepository.findByTeamMangerIdForDelete(memberId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/site/codemonster/comon/domain/team/service/TeamLowService.java
+++ b/src/main/java/site/codemonster/comon/domain/team/service/TeamLowService.java
@@ -84,8 +84,8 @@ public class TeamLowService {
     }
 
     @Transactional(readOnly = true)
-    public List<Team> findByTeamMangerIdForDelete(Long memberId) {
-        return teamRepository.findByTeamMangerIdForDelete(memberId);
+    public List<Team> findByTeamMangerId(Long memberId) {
+        return teamRepository.findByTeamMangerId(memberId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/site/codemonster/comon/domain/team/service/TeamService.java
+++ b/src/main/java/site/codemonster/comon/domain/team/service/TeamService.java
@@ -38,7 +38,6 @@ public class TeamService {
     private final MemberLowService memberLowService;
     private final TeamMemberLowService teamMemberLowService;
     private final ArticleLowService articleLowService;
-    private final ArticleImageLowService articleImageLowService;
     private final TeamRecruitLowService teamRecruitLowService;
     private final TeamRecommendationHighService teamRecommendationHighService;
     private final RecommendationHistoryLowService recommendationHistoryLowService;
@@ -142,7 +141,7 @@ public class TeamService {
 
         teamRecommendationHighService.deleteTeamRecommendation(team.getTeamId());
 
-        articleLowService.deleteByTeamTeamId(team.getTeamId());
+        articleLowService.deleteByTeamId(team.getTeamId());
 
         teamMemberLowService.deleteTeamMemberByTeamId(team.getTeamId());
 

--- a/src/main/java/site/codemonster/comon/domain/teamMember/repository/TeamMemberRepository.java
+++ b/src/main/java/site/codemonster/comon/domain/teamMember/repository/TeamMemberRepository.java
@@ -1,6 +1,8 @@
 package site.codemonster.comon.domain.teamMember.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
 import site.codemonster.comon.domain.auth.entity.Member;
 import site.codemonster.comon.domain.team.entity.Team;
 import site.codemonster.comon.domain.teamMember.entity.TeamMember;
@@ -49,4 +51,9 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
 
     @Query(value = "select * from team_member tm where tm.team_id = :teamId and tm.is_team_manager = true limit 1", nativeQuery = true)
     Optional<TeamMember> findFirstTeamManagerByTeamId(@Param("teamId") Long teamId);
+
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select tm from TeamMember tm where tm.team.teamId = :teamId and tm.isTeamManager = true")
+    List<TeamMember> findTeamManagerByTeamIdForUpdate(Long teamId);
 }

--- a/src/main/java/site/codemonster/comon/domain/teamMember/service/TeamMemberLowService.java
+++ b/src/main/java/site/codemonster/comon/domain/teamMember/service/TeamMemberLowService.java
@@ -114,4 +114,9 @@ public class TeamMemberLowService {
             throw new TeamMemberInvalidException();
         }
     }
+
+    @Transactional(readOnly = true)
+    public List<TeamMember> findTeamManagerByTeamIdForUpdate(Long teamId) {
+        return teamMemberRepository.findTeamManagerByTeamIdForUpdate(teamId);
+    }
 }

--- a/src/main/java/site/codemonster/comon/domain/teamMember/service/TeamMemberService.java
+++ b/src/main/java/site/codemonster/comon/domain/teamMember/service/TeamMemberService.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 @Slf4j
 public class TeamMemberService {
     private final ArticleLowService articleLowService;
-    private final ArticleImageLowService articleImageLowService;
     private final MemberLowService memberLowService;
     private final TeamLowService teamLowService;
     private final TeamRecruitLowService teamRecruitLowService;

--- a/src/main/resources/application-prompt.properties
+++ b/src/main/resources/application-prompt.properties
@@ -34,75 +34,66 @@ Generally, **users provide coding test solution information as follows.** Refere
 ```\n\n\
 ---\n\n\
 ## Output Format\n\n\
-[Provide feedback according to the following output format (Exception: If the user inputs content that is not code, identify this and ask the user clarifying questions in return):]\n\n\
-### ⭐ 종합 평가: X.X / 5.0\n\n\
-[Evaluation of User's Coding Test Solution]\n\n\
-[Criteria, Score, Rationale]\n\n\
-- 정확성: [X/5] - [Pass/fail of test cases, handling of edge cases]\n\n\
-- 효율성: [X/5] - [Optimality of time/space complexity]\n\n\
-- 가독성: [X/5] - [Variable naming, code structure, use of comments]\n\n\
-- 창의성: [X/5] - [Use of unique approaches or techniques]\n\n\
----\n\n\
-### 1. 문제 핵심 포인트\n\n\
-> *Briefly explain the most critical concept or trap of this problem in 2-3 lines.*\n\n\
----\n\n\
-### 2. 아이디어 및 접근 방식 분석\n\n\
-*Analyze whether the algorithm and data structures selected by the user to solve the problem were appropriate.*\n\n\
-**사용자의 접근법:**\n\n\
-- [Algorithm/Data Structure Used: (e.g., BFS, Dynamic Programming, HashMap, etc.)]\n\n\
-- [Core Idea: Summary of how the user interpreted and solved the problem]\n\n\
-- [Strengths of Approach: Explain why this method is effective]\n\n\
-**대안적 접근법 (If applicable):**\n\n\
-- [Brief mention of other possible solutions and trade-offs]\n\n\
----\n\n\
-### 3. 잘한 부분 (2-3개)\n\n\
-*Mention 2-3 praiseworthy points in the user's solution and provide reasons.*\n\n\
-- **[line. X]**\n\n\
-  - [First Strength]\n\n\
-  - [What is good: Specific explanation]\n\n\
-  - [Why it is good: Explain effect or benefit (complexity improvement, readability enhancement, etc.)]\n\n\
-- **[line. Y]**\n\n\
-  - [Second Strength]\n\n\
-  - [What is good: Specific explanation]\n\n\
-  - [Why it is good: Explain effect or benefit]\n\n\
-- **[line. Z]** (If applicable)\n\n\
-  - [Third Strength]\n\n\
-  - [What is good: Specific explanation]\n\n\
----\n\n\
-### 4. 시간 복잡도 및 최적화 분석\n\n\
-**현재 복잡도:**\n\n\
-- Time Complexity: [O(?) - Analysis by operation step]\n\n\
-- Space Complexity: [O(?) - Memory analysis by data structure used]\n\n\
-**최적화 가능성:**\n\n\
-- Theoretical Optimal Complexity: [O(?)]\n\n\
-- Gap analysis with current solution\n\n\
-- Specific optimization methods (If applicable)\n\n\
----\n\n\
-### 5. 개선 제안 (1-2개)\n\n\
-- **[line. X]** First Improvement Point\n\n\
-  - Current Issue: Mention what can be improved\n\n\
-  - Improvement Method: Suggest specific modification\n\n\
-  - Expected Effect: Benefit gained upon improvement (complexity, readability, etc.)\n\n\
-  - Code Example (If needed):\n\n\
-```\n\n\
-    // Improved code snippet (in the same language)\n\n\
-```\n\n\
-- **[line. Y]** Second Improvement Point (If needed)\n\n\
-  - Current Issue, Improvement Method, Expected Effect\n\n\
-*If there are no parts to improve:*\n\n\
-> "현재 풀이가 해당 문제 유형에 대해 매우 효율적이며, 모범 답안 수준입니다."\n\n\
----\n\n\
-### 6. 학습 포인트\n\n\
-Summarize the key learning points obtainable from this problem in 2-3 lines.\n\n\
-- Algorithms/Patterns learned\n\n\
-- Techniques to remember\n\n\
-- Situations for extended application\n\n\
----\n\n\
-### 7. 관련 추천 문제\n\n\
-*[Difficulty, Problem Name, Source, Relevance]*\n\n\
-- **난이도**: [쉬움 🟢/중간 🟡/어려움 🔴 Label]\n\n\
-  - **문제 이름**: [LeetCode/Baekjoon 등 난이도 별 문제]\n\n\
-  - **연관성**: [난이도에 따른 관련된 문제 제공(예: 쉬우면 기본, 중간이면 변형, 어려움이면 심화 등]\n\n\
----\n\n\
-**⚠️ [System Ready]**: **The user will now provide a problem solution. Be familiar with all the content above and prepare to provide kind and clear feedback.**\n\n\
-—\n\n\
+Provide feedback in plain text using the structure below.\n\n\
+Do not reproduce Markdown symbols from this template.\n\n\
+Do not use headings, bold text, blockquotes, or fenced code blocks.\n\n\
+종합 평가: X.X / 5.0\n\n\
+[사용자의 코딩 테스트 풀이에 대한 전체 평가]\n\n\
+[평가 기준, 점수, 근거]\n\n\
+- 정확성: [X/5] - [테스트 케이스 통과 여부, 예외 처리]\n\n\
+- 효율성: [X/5] - [시간/공간 복잡도의 적절성]\n\n\
+- 가독성: [X/5] - [변수명, 코드 구조, 주석 활용]\n\n\
+- 창의성: [X/5] - [독창적인 접근이나 기법 사용 여부]\n\n\
+구분선: ---\n\n\
+1. 문제 핵심 포인트\n\n\
+[2~3줄 설명]\n\n\
+구분선: ---\n\n\
+2. 아이디어 및 접근 방식 분석\n\n\
+사용자의 접근법:\n\n\
+- [사용한 알고리즘/자료구조]\n\n\
+- [핵심 아이디어]\n\n\
+- [접근 방식의 장점]\n\n\
+대안적 접근법:\n\n\
+- [가능한 다른 풀이와 트레이드오프]\n\n\
+구분선: ---\n\n\
+3. 잘한 부분 (2-3개)\n\n\
+[line. X]\n\n\
+- [잘한 점]\n\n\
+- [구체적으로 왜 좋은지]\n\n\
+- [복잡도/가독성/안정성 측면의 이점]\n\n\
+[line. Y]\n\n\
+- [잘한 점]\n\n\
+- [구체적으로 왜 좋은지]\n\n\
+구분선: ---\n\n\
+4. 시간 복잡도 및 최적화 분석\n\n\
+현재 복잡도:\n\n\
+- Time Complexity: O(?)\n\n\
+- Space Complexity: O(?)\n\n\
+최적화 가능성:\n\n\
+- 이론적 최적 복잡도: O(?)\n\n\
+- 현재 풀이와의 차이\n\n\
+- 구체적인 최적화 방법\n\n\
+구분선: ---\n\n\
+5. 개선 제안 (1-2개)\n\n\
+[line. X] 첫 번째 개선 포인트\n\n\
+- 현재 이슈:\n\n\
+- 개선 방법:\n\n\
+- 기대 효과:\n\n\
+- 코드 예시(필요 시): 아래에 일반 텍스트로 들여쓰기하여 작성\n\n\
+[line. Y] 두 번째 개선 포인트\n\n\
+- 현재 이슈:\n\n\
+- 개선 방법:\n\n\
+- 기대 효과:\n\n\
+개선점이 없으면 다음 문장을 그대로 출력:\n\n\
+현재 풀이가 해당 문제 유형에 대해 매우 효율적이며, 모범 답안 수준입니다.\n\n\
+구분선: ---\n\n\
+6. 학습 포인트\n\n\
+- 배운 알고리즘/패턴\n\n\
+- 기억해야 할 테크닉\n\n\
+- 확장 적용 가능 상황\n\n\
+구분선: ---\n\n\
+7. 관련 추천 문제\n\n\
+- 난이도: [쉬움/중간/어려움]\n\n\
+- 문제 이름:\n\n\
+- 출처:\n\n\
+- 연관성:\n\n\

--- a/src/test/java/site/codemonster/comon/domain/auth/controller/MemberControllerTest.java
+++ b/src/test/java/site/codemonster/comon/domain/auth/controller/MemberControllerTest.java
@@ -301,7 +301,7 @@ class MemberControllerTest {
             softly.assertThat(apiResponse.getMessage()).isEqualTo(ResponseMessageEnum.MEMBER_DELETE_SUCCESS.getMessage());
             softly.assertThat(findMember.isPresent()).isFalse();
             softly.assertThat(teamRecommendationDayRepository.findById(teamRecommendationDay.getId()).isPresent()).isFalse();
-            softly.assertThat(teamRecommendationRepository.findById(teamRecommendationDay.getId()).isPresent()).isFalse();
+            softly.assertThat(teamRecommendationRepository.findById(teamRecommendation.getId()).isPresent()).isFalse();
             softly.assertThat(recommendationHistoryRepository.findById(recommendationHistory.getHistoryId()).isPresent()).isFalse();
         });
     }
@@ -344,7 +344,7 @@ class MemberControllerTest {
             softly.assertThat(apiResponse.getMessage()).isEqualTo(ResponseMessageEnum.MEMBER_DELETE_SUCCESS.getMessage());
             softly.assertThat(findMember.isPresent()).isFalse();
             softly.assertThat(teamRecommendationDayRepository.findById(teamRecommendationDay.getId()).isPresent()).isTrue();
-            softly.assertThat(teamRecommendationRepository.findById(teamRecommendationDay.getId()).isPresent()).isTrue();
+            softly.assertThat(teamRecommendationRepository.findById(teamRecommendation.getId()).isPresent()).isTrue();
             softly.assertThat(recommendationHistoryRepository.findById(recommendationHistory.getHistoryId()).isPresent()).isTrue();
         });
     }

--- a/src/test/java/site/codemonster/comon/domain/auth/controller/MemberControllerTest.java
+++ b/src/test/java/site/codemonster/comon/domain/auth/controller/MemberControllerTest.java
@@ -22,6 +22,14 @@ import site.codemonster.comon.domain.auth.dto.response.MemberInfoResponse;
 import site.codemonster.comon.domain.auth.dto.response.MemberProfileResponse;
 import site.codemonster.comon.domain.auth.entity.Member;
 import site.codemonster.comon.domain.auth.repository.MemberRepository;
+import site.codemonster.comon.domain.problem.entity.Problem;
+import site.codemonster.comon.domain.problem.repository.ProblemRepository;
+import site.codemonster.comon.domain.recommendation.entity.RecommendationHistory;
+import site.codemonster.comon.domain.recommendation.entity.TeamRecommendation;
+import site.codemonster.comon.domain.recommendation.entity.TeamRecommendationDay;
+import site.codemonster.comon.domain.recommendation.repository.RecommendationHistoryRepository;
+import site.codemonster.comon.domain.recommendation.repository.TeamRecommendationDayRepository;
+import site.codemonster.comon.domain.recommendation.repository.TeamRecommendationRepository;
 import site.codemonster.comon.domain.team.dto.response.TeamAbstractResponse;
 import site.codemonster.comon.domain.team.entity.Team;
 import site.codemonster.comon.domain.team.repository.TeamRepository;
@@ -68,6 +76,18 @@ class MemberControllerTest {
 
     @Autowired
     private ArticleCommentRepository articleCommentRepository;
+
+    @Autowired
+    private TeamRecommendationRepository teamRecommendationRepository;
+
+    @Autowired
+    private TeamRecommendationDayRepository teamRecommendationDayRepository;
+
+    @Autowired
+    private RecommendationHistoryRepository recommendationHistoryRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
 
     @Test
     @DisplayName("회원 등록 성공")
@@ -249,8 +269,12 @@ class MemberControllerTest {
         Member member = memberRepository.save(TestUtil.createMember());
         Member otherMember = memberRepository.save(TestUtil.createOtherMember());
         Long memberId = member.getId();
+        Problem problem = problemRepository.save(TestUtil.createProblem());
         Team team = teamRepository.save(TestUtil.createTeam());
-        TeamMember createCommentMember = teamMemberRepository.save(TestUtil.createTeamMember(team, member));
+        TeamRecommendation teamRecommendation = teamRecommendationRepository.save(TestUtil.createTeamRecommendation(team));
+        TeamRecommendationDay teamRecommendationDay = teamRecommendationDayRepository.save(TestUtil.createTeamRecommendationDay(teamRecommendation));
+        RecommendationHistory recommendationHistory = recommendationHistoryRepository.save(TestUtil.createRecommendationHistory(team, problem));
+        TeamMember createCommentMember = teamMemberRepository.save(TestUtil.createTeamManager(team, member));
         TeamMember createArticleMember = teamMemberRepository.save(TestUtil.createTeamMember(team, otherMember));
         Article article = articleRepository.save(TestUtil.createArticle(team, otherMember));
         ArticleComment articleComment1 = articleCommentRepository.save(TestUtil.createArticleComment(article, member));
@@ -271,15 +295,14 @@ class MemberControllerTest {
 
         Optional<Member> findMember = memberRepository.findByUuid(member.getUuid());
 
-        ArticleComment deletedComment = articleCommentRepository.findById(articleComment1.getCommentId()).get();
-
         assertSoftly(softly -> {
             softly.assertThat(apiResponse.getStatus()).isEqualTo(ApiResponse.SUCCESS);
             softly.assertThat(apiResponse.getCode()).isEqualTo(HttpStatus.OK.value());
             softly.assertThat(apiResponse.getMessage()).isEqualTo(ResponseMessageEnum.MEMBER_DELETE_SUCCESS.getMessage());
             softly.assertThat(findMember.isPresent()).isFalse();
-            softly.assertThat(deletedComment.getIsDeleted()).isTrue();
-            softly.assertThat(deletedComment.getMember()).isNull();
+            softly.assertThat(teamRecommendationDayRepository.findById(teamRecommendationDay.getId()).isPresent()).isFalse();
+            softly.assertThat(teamRecommendationRepository.findById(teamRecommendationDay.getId()).isPresent()).isFalse();
+            softly.assertThat(recommendationHistoryRepository.findById(recommendationHistory.getHistoryId()).isPresent()).isFalse();
         });
     }
 }

--- a/src/test/java/site/codemonster/comon/domain/auth/controller/MemberControllerTest.java
+++ b/src/test/java/site/codemonster/comon/domain/auth/controller/MemberControllerTest.java
@@ -264,8 +264,8 @@ class MemberControllerTest {
     }
 
     @Test
-    @DisplayName("회원 탈퇴 성공")
-    void getMemberInfoSuccess() throws Exception {
+    @DisplayName("회원 탈퇴 성공 - 팀매니저가 한 명이면 팀을 삭제")
+    void getMemberInfoSuccessCase1() throws Exception {
         Member member = memberRepository.save(TestUtil.createMember());
         Member otherMember = memberRepository.save(TestUtil.createOtherMember());
         Long memberId = member.getId();
@@ -303,6 +303,49 @@ class MemberControllerTest {
             softly.assertThat(teamRecommendationDayRepository.findById(teamRecommendationDay.getId()).isPresent()).isFalse();
             softly.assertThat(teamRecommendationRepository.findById(teamRecommendationDay.getId()).isPresent()).isFalse();
             softly.assertThat(recommendationHistoryRepository.findById(recommendationHistory.getHistoryId()).isPresent()).isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 성공 - 팀매니저가 한 명 이상이라면 팀을 삭제하지 않는다.")
+    void getMemberInfoSuccessCase2() throws Exception {
+        Member member = memberRepository.save(TestUtil.createMember());
+        Member otherMember = memberRepository.save(TestUtil.createOtherMember());
+        Long memberId = member.getId();
+        Problem problem = problemRepository.save(TestUtil.createProblem());
+        Team team = teamRepository.save(TestUtil.createTeam());
+        TeamRecommendation teamRecommendation = teamRecommendationRepository.save(TestUtil.createTeamRecommendation(team));
+        TeamRecommendationDay teamRecommendationDay = teamRecommendationDayRepository.save(TestUtil.createTeamRecommendationDay(teamRecommendation));
+        RecommendationHistory recommendationHistory = recommendationHistoryRepository.save(TestUtil.createRecommendationHistory(team, problem));
+        TeamMember createCommentMember = teamMemberRepository.save(TestUtil.createTeamManager(team, member));
+        TeamMember createArticleMember = teamMemberRepository.save(TestUtil.createTeamManager(team, otherMember));
+        Article article = articleRepository.save(TestUtil.createArticle(team, otherMember));
+        ArticleComment articleComment1 = articleCommentRepository.save(TestUtil.createArticleComment(article, member));
+        ArticleComment articleComment2 = articleCommentRepository.save(TestUtil.createArticleComment(article, member));
+        ArticleComment articleComment3 = articleCommentRepository.save(TestUtil.createArticleComment(article, member));
+
+        TestSecurityContextInjector.inject(member);
+
+        String response = mockMvc.perform(delete("/api/v1/members")
+                        .with(securityContext(SecurityContextHolder.getContext()))
+                )
+                .andReturn()
+                .getResponse()
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        ApiResponse<Void> apiResponse = objectMapper.readValue(response, new TypeReference<ApiResponse<Void>>() {
+        });
+
+        Optional<Member> findMember = memberRepository.findByUuid(member.getUuid());
+
+        assertSoftly(softly -> {
+            softly.assertThat(apiResponse.getStatus()).isEqualTo(ApiResponse.SUCCESS);
+            softly.assertThat(apiResponse.getCode()).isEqualTo(HttpStatus.OK.value());
+            softly.assertThat(apiResponse.getMessage()).isEqualTo(ResponseMessageEnum.MEMBER_DELETE_SUCCESS.getMessage());
+            softly.assertThat(findMember.isPresent()).isFalse();
+            softly.assertThat(teamRecommendationDayRepository.findById(teamRecommendationDay.getId()).isPresent()).isTrue();
+            softly.assertThat(teamRecommendationRepository.findById(teamRecommendationDay.getId()).isPresent()).isTrue();
+            softly.assertThat(recommendationHistoryRepository.findById(recommendationHistory.getHistoryId()).isPresent()).isTrue();
         });
     }
 }

--- a/src/test/java/site/codemonster/comon/domain/auth/service/MemberServiceTest.java
+++ b/src/test/java/site/codemonster/comon/domain/auth/service/MemberServiceTest.java
@@ -1,0 +1,73 @@
+package site.codemonster.comon.domain.auth.service;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import site.codemonster.comon.domain.auth.entity.Member;
+import site.codemonster.comon.domain.auth.repository.MemberRepository;
+import site.codemonster.comon.domain.team.entity.Team;
+import site.codemonster.comon.domain.team.repository.TeamRepository;
+import site.codemonster.comon.domain.teamMember.repository.TeamMemberRepository;
+import site.codemonster.comon.domain.util.TestUtil;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@SpringBootTest
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Test
+    void deleteMemberConcurrencyTest() throws InterruptedException {
+
+        Member member1 = memberRepository.save(TestUtil.createMember());
+        Member member2 = memberRepository.save(TestUtil.createOtherMember());
+
+        List<Member> members = Arrays.asList(member1, member2);
+
+        Team team = teamRepository.save(TestUtil.createTeam());
+
+        teamMemberRepository.save(TestUtil.createTeamManager(team, member1));
+        teamMemberRepository.save(TestUtil.createTeamManager(team, member2));
+
+        int threadCount = 2;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+        for (Member member : members) {
+            executorService.submit(() -> {
+                try{
+                    memberService.deleteMember(member.getId());
+
+                } catch (Exception e) {
+
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+
+        countDownLatch.await();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(teamRepository.existsById(team.getTeamId())).isFalse();
+        });
+    }
+}


### PR DESCRIPTION
## 🔥 관련 이슈

- close: #62 

---

## 📝 작업 상세 설명
해결한 문제는 다음과 같습니다.

1. 기존 팀 삭제가 팀 매니저가 여러명이어도 한명만 나가도 팀이 삭제되는 로직을 변경
2. 변경시에는 동시성 문제를 고려해야합니다. 비관적락 `@Lock(LockModeType.PESSIMISTIC_WRITE)`를 통해 동시성 제어를 수행했습니다.

```java
List<Team> teamsManagedByMember = teamLowService.findByTeamMangerId(memberId);

for (Team team : teamsManagedByMember) {
    Long teamId = team.getTeamId();

    List<TeamMember> teamManagers = teamMemberLowService.findTeamManagerByTeamIdForUpdate(teamId);

    if (teamManagers.size() > 1) continue;

    articleLowService.deleteByTeamId(teamId);

    teamLowService.deleteById(teamId);
}
```
여기서 동시성 제어를 수행해야하는 부분은 `findTeamManagerByTeamIdForUpdate`입니다.
해당 메서드로 반환된 `teamManagers`들은 다른 트랜잭션에서 접근하지 못합니다.

<img width="1072" height="284" alt="image" src="https://github.com/user-attachments/assets/ca250b85-a0fd-44cb-b2e3-e1f3c92c8781" />

<img width="1080" height="196" alt="image" src="https://github.com/user-attachments/assets/81403867-48b7-4a96-8824-627abc33792d" />

실제로 테스트 코드를 통해 확인해봤습니다.
`@Lock(LockModeType.PESSIMISTIC_WRITE)`를 사용하기 전 후로 테스트의 성공/실패 여부가 바뀝니다.

