### PR TITLE
refactor: 알람 deepLink, routingId, alarmType 추가

### DIFF
--- a/src/main/java/site/codemonster/comon/domain/alarm/dto/AlarmResponse.java
+++ b/src/main/java/site/codemonster/comon/domain/alarm/dto/AlarmResponse.java
@@ -5,14 +5,20 @@ import site.codemonster.comon.domain.alarm.entity.Alarm;
 public record AlarmResponse(
         Long alarmId,
         String title,
-        String content
+        String content,
+        String deepLink,
+        Long routingId,
+        String alarmType
 ) {
 
     public AlarmResponse(Alarm alarm) {
         this(
                 alarm.getId(),
                 alarm.getTitle(),
-                alarm.getContent()
+                alarm.getContent(),
+                alarm.getDeepLink(),
+                alarm.getRoutingId(),
+                alarm.getAlarmType()
         );
     }
 }

--- a/src/main/java/site/codemonster/comon/domain/alarm/entity/Alarm.java
+++ b/src/main/java/site/codemonster/comon/domain/alarm/entity/Alarm.java
@@ -31,9 +31,19 @@ public class Alarm {
     )
     private Member member;
 
-    public Alarm(String title, String content, Member member) {
+    @Column(length = 1000)
+    private String deepLink;
+
+    private Long routingId;
+
+    private String alarmType;
+
+    public Alarm(String title, String content, Member member, String deepLink, Long routingId, AlarmType alarmType) {
         this.title = title;
         this.content = content;
         this.member = member;
+        this.deepLink = deepLink;
+        this.routingId = routingId;
+        this.alarmType = alarmType.name();
     }
 }

--- a/src/main/java/site/codemonster/comon/domain/alarm/entity/AlarmType.java
+++ b/src/main/java/site/codemonster/comon/domain/alarm/entity/AlarmType.java
@@ -1,0 +1,15 @@
+package site.codemonster.comon.domain.alarm.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum AlarmType {
+
+    ARTICLE_COMMENT_ALARM("게시글에 댓글이 달렸습니다.");
+
+    private final String message;
+
+    AlarmType(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/site/codemonster/comon/domain/article/controller/ArticleCommentController.java
+++ b/src/main/java/site/codemonster/comon/domain/article/controller/ArticleCommentController.java
@@ -38,7 +38,13 @@ public class ArticleCommentController {
     ) {
         ArticleCreateCommentResponse response = articleCommentHighService.createComment(articleId, member, request);
 
-        fcmService.sendArticleAlarm(response.articleOwnerId(), response.articleTitle(), response.commentDescription());
+        fcmService.sendArticleAlarm(
+                response.articleOwnerId(),
+                response.articleTitle(),
+                response.commentDescription(),
+                response.deepLink(),
+                response.routingId()
+        );
 
         return ResponseEntity.status(COMMENT_CREATE_SUCCESS.getStatusCode())
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/main/java/site/codemonster/comon/domain/article/dto/response/ArticleCreateCommentResponse.java
+++ b/src/main/java/site/codemonster/comon/domain/article/dto/response/ArticleCreateCommentResponse.java
@@ -4,6 +4,8 @@ public record ArticleCreateCommentResponse(
         Long commentId,
         Long articleOwnerId,
         String articleTitle,
-        String commentDescription
+        String commentDescription,
+        String deepLink,
+        Long routingId
 ) {
 }

--- a/src/main/java/site/codemonster/comon/domain/article/service/ArticleCommentHighService.java
+++ b/src/main/java/site/codemonster/comon/domain/article/service/ArticleCommentHighService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.codemonster.comon.domain.alarm.entity.Alarm;
+import site.codemonster.comon.domain.alarm.entity.AlarmType;
 import site.codemonster.comon.domain.alarm.service.AlarmLowService;
 import site.codemonster.comon.domain.article.dto.request.ArticleCommentRequest;
 import site.codemonster.comon.domain.article.dto.response.ArticleCommentResponse;
@@ -25,6 +26,8 @@ import java.util.List;
 @Transactional
 public class ArticleCommentHighService {
 
+    private static final String ARTICLE_COMMENT_DEEP_LINK = "/api/v1/articles/%s/by-date?date=%s";
+
     private final ArticleCommentLowService articleCommentLowService;
     private final ArticleLowService articleLowService;
     private final TeamMemberLowService teamMemberLowService;
@@ -43,10 +46,19 @@ public class ArticleCommentHighService {
 
         String title = article.getArticleTitle() + "에 댓글이 달렸습니다.";
 
-        alarmLowService.save(new Alarm(title, articleComment.getDescription(), articleOwner));
+        String deepLink = ARTICLE_COMMENT_DEEP_LINK.formatted(article.getTeam().getTeamId(), article.getCreatedDate().toLocalDate().toString());
+
+        alarmLowService.save(new Alarm(title, articleComment.getDescription(), articleOwner, deepLink, articleId, AlarmType.ARTICLE_COMMENT_ALARM));
 
 
-        return new ArticleCreateCommentResponse(articleComment.getCommentId(), articleOwner.getId(), title, articleComment.getDescription());
+        return new ArticleCreateCommentResponse(
+                articleComment.getCommentId(),
+                articleOwner.getId(),
+                title,
+                articleComment.getDescription(),
+                deepLink,
+                articleId
+        );
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/site/codemonster/comon/domain/fcm/service/FcmService.java
+++ b/src/main/java/site/codemonster/comon/domain/fcm/service/FcmService.java
@@ -6,13 +6,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import site.codemonster.comon.domain.alarm.entity.Alarm;
-import site.codemonster.comon.domain.alarm.service.AlarmLowService;
-import site.codemonster.comon.domain.article.entity.Article;
-import site.codemonster.comon.domain.article.entity.ArticleComment;
-import site.codemonster.comon.domain.auth.entity.Member;
+import site.codemonster.comon.domain.alarm.entity.AlarmType;
 import site.codemonster.comon.domain.fcm.dto.DeviceTokenRequest;
 import site.codemonster.comon.domain.fcm.entity.DeviceToken;
+import site.codemonster.comon.domain.auth.entity.Member;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,18 +33,18 @@ public class FcmService {
     }
 
     @Async("sendAlarm")
-    public void sendArticleAlarm(Long memberId, String articleTitle, String articleComment) {
+    public void sendArticleAlarm(Long memberId, String articleTitle, String articleComment, String deepLink, Long routingId) {
 
         List<DeviceToken> deviceTokens = deviceTokenLowService.findByMemberId(memberId);
 
 
         deviceTokens.forEach(deviceToken -> {
-            sendMessageTo(deviceToken.getToken(), articleTitle, articleComment);
+            sendMessageTo(deviceToken.getToken(), articleTitle, articleComment, deepLink, routingId, AlarmType.ARTICLE_COMMENT_ALARM);
         });
 
     }
 
-    private void sendMessageTo(String targetToken, String title, String body) {
+    private void sendMessageTo(String targetToken, String title, String body, String deepLink, Long routingId, AlarmType alarmType) {
 
         Message message = Message.builder()
                 .setToken(targetToken)
@@ -57,6 +54,9 @@ public class FcmService {
                                 .setBody(body)
                                 .build()
                 )
+                .putData("deepLink", deepLink)
+                .putData("routingId", String.valueOf(routingId))
+                .putData("alarmType", alarmType.name())
                 .build();
 
         FirebaseMessaging firebaseMessaging = FirebaseMessaging.getInstance();

--- a/src/test/java/site/codemonster/comon/domain/alarm/controller/AlarmControllerTest.java
+++ b/src/test/java/site/codemonster/comon/domain/alarm/controller/AlarmControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import site.codemonster.comon.domain.alarm.entity.AlarmType;
 import site.codemonster.comon.domain.alarm.repository.AlarmRepository;
 import site.codemonster.comon.domain.auth.entity.Member;
 import site.codemonster.comon.domain.auth.repository.MemberRepository;
@@ -42,9 +43,9 @@ class AlarmControllerTest {
         Member member = memberRepository.save(TestUtil.createMember());
         Member otherMember = memberRepository.save(TestUtil.createOtherMember());
 
-        alarmRepository.save(new Alarm("첫 번째 알람", "첫 번째 내용", member));
-        alarmRepository.save(new Alarm("두 번째 알람", "두 번째 내용", member));
-        alarmRepository.save(new Alarm("다른 회원 알람", "다른 회원 내용", otherMember));
+        alarmRepository.save(new Alarm("첫 번째 알람", "첫 번째 내용", member, "/api/v1/articles/1/by-date?date=2026-05-23", 1L, AlarmType.ARTICLE_COMMENT_ALARM));
+        alarmRepository.save(new Alarm("두 번째 알람", "두 번째 내용", member, "/api/v1/articles/1/by-date?date=2026-05-23", 1L, AlarmType.ARTICLE_COMMENT_ALARM));
+        alarmRepository.save(new Alarm("다른 회원 알람", "다른 회원 내용", otherMember, "/api/v1/articles/2/by-date?date=2026-05-23", 2L, AlarmType.ARTICLE_COMMENT_ALARM));
 
         TestSecurityContextInjector.inject(member);
 
@@ -58,8 +59,14 @@ class AlarmControllerTest {
                 .andExpect(jsonPath("$.code").value(HttpStatus.OK.value()))
                 .andExpect(jsonPath("$.data.content[0].title").value("두 번째 알람"))
                 .andExpect(jsonPath("$.data.content[0].content").value("두 번째 내용"))
+                .andExpect(jsonPath("$.data.content[0].deepLink").value("/api/v1/articles/1/by-date?date=2026-05-23"))
+                .andExpect(jsonPath("$.data.content[0].routingId").value(1))
+                .andExpect(jsonPath("$.data.content[0].alarmType").value(AlarmType.ARTICLE_COMMENT_ALARM.name()))
                 .andExpect(jsonPath("$.data.content[1].title").value("첫 번째 알람"))
                 .andExpect(jsonPath("$.data.content[1].content").value("첫 번째 내용"))
+                .andExpect(jsonPath("$.data.content[1].deepLink").value("/api/v1/articles/1/by-date?date=2026-05-23"))
+                .andExpect(jsonPath("$.data.content[1].routingId").value(1))
+                .andExpect(jsonPath("$.data.content[1].alarmType").value(AlarmType.ARTICLE_COMMENT_ALARM.name()))
                 .andExpect(jsonPath("$.data.page.number").value(0))
                 .andExpect(jsonPath("$.data.page.size").value(5))
                 .andExpect(jsonPath("$.data.page.totalElements").value(2));


### PR DESCRIPTION
## 🔥 관련 이슈

- close: #68 

---

## 📝 작업 상세 설명
 댓글 알람에 클라이언트 라우팅에 필요한 메타데이터를 추가했습니다.

 기존에는 알람과 FCM payload에 제목/내용만 포함되어 있어서, 앱에서 알람 클릭 시 어떤 화면으로 이동해야 하는지 추가 판단이 필요했습니다.

아래 정보를 함께 저장/전달하도록 수정했습니다.

  - `deepLink`: 알람 클릭 시 이동할 API 경로
  - `routingId`: 이동 대상 식별자
  - `alarmType`: 알람 타입 구분값

deepLink를 통해 해당 게시글이 올라온 팀의 날짜 캘린더로 이동한 후에 routingId를 통해 게시글을 띄워줘야할 것 같습니다.

이제 해당 내용바탕으로 알람 프론트 작업 마무리하면 될 것 같습니다!

---

