### PR TITLE
feat: 팀 내 페이지 개인화 대시보드 구현

### DIFF
--- a/src/main/java/site/codemonster/comon/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/site/codemonster/comon/domain/article/repository/ArticleRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -74,4 +75,12 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             "WHERE a.team.teamId IN :teamIds AND a.articleCategory = 'CODING_TEST' " +
             "GROUP BY a.team.teamId")
     List<CodingTestCountProjection> countCodingTestByTeamIds(@Param("teamIds") List<Long> teamIds);
+
+    long countByMemberId(Long memberId);
+
+    @Query("SELECT article.createdDate FROM Article article " +
+            "WHERE article.member.id = :memberId AND article.team.teamId = :teamId " +
+            "AND article.createdDate >= :fromInclusive AND article.createdDate < :toExclusive")
+    List<LocalDateTime> findCreatedDatesByMemberAndTeamInRange(
+            Long memberId, Long teamId, LocalDateTime fromInclusive, LocalDateTime toExclusive);
 }

--- a/src/main/java/site/codemonster/comon/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/site/codemonster/comon/domain/article/repository/ArticleRepository.java
@@ -82,5 +82,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             "WHERE article.member.id = :memberId AND article.team.teamId = :teamId " +
             "AND article.createdDate >= :fromInclusive AND article.createdDate < :toExclusive")
     List<LocalDateTime> findCreatedDatesByMemberAndTeamInRange(
-            Long memberId, Long teamId, LocalDateTime fromInclusive, LocalDateTime toExclusive);
+            @Param("memberId") Long memberId,
+            @Param("teamId") Long teamId,
+            @Param("fromInclusive") LocalDateTime fromInclusive,
+            @Param("toExclusive") LocalDateTime toExclusive);
 }

--- a/src/main/java/site/codemonster/comon/domain/article/service/ArticleLowService.java
+++ b/src/main/java/site/codemonster/comon/domain/article/service/ArticleLowService.java
@@ -17,6 +17,7 @@ import site.codemonster.comon.domain.team.entity.Team;
 import site.codemonster.comon.global.error.articles.ArticleNotFoundException;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -129,6 +130,16 @@ public class ArticleLowService {
                         CodingTestCountProjection::getTeamId,
                         CodingTestCountProjection::getCount
                 ));
+    }
+
+    @Transactional(readOnly = true)
+    public long countByMemberId(Long memberId) {
+        return articleRepository.countByMemberId(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LocalDateTime> findCreatedDatesByMemberAndTeamInRange(Long memberId, Long teamId, LocalDateTime fromInclusive, LocalDateTime toExclusive) {
+        return articleRepository.findCreatedDatesByMemberAndTeamInRange(memberId, teamId, fromInclusive, toExclusive);
     }
 
     private void deleteByArticleId(Long articleId) {

--- a/src/main/java/site/codemonster/comon/domain/article/service/ArticleService.java
+++ b/src/main/java/site/codemonster/comon/domain/article/service/ArticleService.java
@@ -11,7 +11,7 @@ import site.codemonster.comon.domain.auth.entity.Member;
 import site.codemonster.comon.domain.problem.entity.Problem;
 import site.codemonster.comon.domain.recommendation.entity.TeamRecommendation;
 import site.codemonster.comon.domain.recommendation.entity.TeamRecommendationDay;
-import site.codemonster.comon.domain.recommendation.repository.TeamRecommendationRepository;
+import site.codemonster.comon.domain.recommendation.service.TeamRecommendationLowService;
 import site.codemonster.comon.domain.team.dto.response.MyTeamResponse;
 import site.codemonster.comon.domain.team.dto.response.TeamDashboardResponse;
 import site.codemonster.comon.domain.team.dto.response.TeamPageResponse;
@@ -48,7 +48,7 @@ public class ArticleService {
     private final TeamMemberLowService teamMemberLowService;
     private final ArticleLowService articleLowService;
     private final TeamLowService teamLowService;
-    private final TeamRecommendationRepository teamRecommendationRepository;
+    private final TeamRecommendationLowService teamRecommendationLowService;
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final int LOOKBACK_DAYS = 90;
@@ -245,7 +245,7 @@ public class ArticleService {
 
     private Map<LocalDate, Long> countSolvesByDate(Long memberId, Long teamId, LocalDate from, LocalDate to) {
         return articleLowService
-                .findCreatedDatesByMemberAndTeamInRange(memberId, teamId, from.atStartOfDay(), to.plusDays(1).atStartOfDay())
+                .findCreatedDatesByMemberAndTeamInRange(memberId, teamId, kstDayStartInSystemDefault(from), kstDayStartInSystemDefault(to.plusDays(1)))
                 .stream()
                 .collect(Collectors.groupingBy(this::toKstDate, Collectors.counting()));
     }
@@ -255,7 +255,7 @@ public class ArticleService {
     }
 
     private Set<DayOfWeek> findRecommendationDays(Long teamId) {
-        return teamRecommendationRepository.findByTeamId(teamId)
+        return teamRecommendationLowService.findByTeamId(teamId)
                 .map(TeamRecommendation::getTeamRecommendationDays)
                 .map(days -> days.stream()
                         .map(TeamRecommendationDay::getDayOfWeek)
@@ -265,5 +265,9 @@ public class ArticleService {
 
     private LocalDate toKstDate(LocalDateTime dateTime) {
         return dateTime.atZone(ZoneId.systemDefault()).withZoneSameInstant(KST).toLocalDate();
+    }
+
+    private LocalDateTime kstDayStartInSystemDefault(LocalDate date) {
+        return date.atStartOfDay(KST).withZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
     }
 }

--- a/src/main/java/site/codemonster/comon/domain/article/service/ArticleService.java
+++ b/src/main/java/site/codemonster/comon/domain/article/service/ArticleService.java
@@ -9,10 +9,15 @@ import site.codemonster.comon.domain.article.entity.Article;
 import site.codemonster.comon.domain.article.enums.ArticleCategory;
 import site.codemonster.comon.domain.auth.entity.Member;
 import site.codemonster.comon.domain.problem.entity.Problem;
+import site.codemonster.comon.domain.recommendation.entity.TeamRecommendation;
+import site.codemonster.comon.domain.recommendation.entity.TeamRecommendationDay;
+import site.codemonster.comon.domain.recommendation.repository.TeamRecommendationRepository;
 import site.codemonster.comon.domain.team.dto.response.MyTeamResponse;
+import site.codemonster.comon.domain.team.dto.response.TeamDashboardResponse;
 import site.codemonster.comon.domain.team.dto.response.TeamPageResponse;
 import site.codemonster.comon.domain.team.entity.Team;
 import site.codemonster.comon.domain.team.service.TeamLowService;
+import site.codemonster.comon.domain.teamMember.entity.TeamMember;
 import site.codemonster.comon.domain.teamMember.service.TeamMemberLowService;
 import site.codemonster.comon.global.error.Team.TeamManagerInvalidException;
 import site.codemonster.comon.global.error.articles.*;
@@ -22,9 +27,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static site.codemonster.comon.domain.article.enums.ArticleCategory.fromName;
 import static site.codemonster.comon.domain.article.enums.ArticleCategory.getSubjectCategories;
@@ -37,6 +48,10 @@ public class ArticleService {
     private final TeamMemberLowService teamMemberLowService;
     private final ArticleLowService articleLowService;
     private final TeamLowService teamLowService;
+    private final TeamRecommendationRepository teamRecommendationRepository;
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final int LOOKBACK_DAYS = 90;
 
     public Article articleCreate(Member member, ArticleCreateRequest articleCreateRequest) {
 
@@ -211,5 +226,44 @@ public class ArticleService {
         return articles.stream()
                 .map(ArticleResponse::new)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public TeamDashboardResponse getDashboard(Member member, Long teamId) {
+        TeamMember teamMember = teamMemberLowService.getTeamMemberByTeamIdAndMemberId(teamId, member);
+
+        LocalDate today = LocalDate.now(KST);
+        LocalDate joinDate = toKstDate(teamMember.getCreatedDate());
+        LocalDate lookbackFloor = laterOf(joinDate, today.minusDays(LOOKBACK_DAYS));
+
+        Map<LocalDate, Long> solveCountsByDate = countSolvesByDate(member.getId(), teamId, lookbackFloor, today);
+        Set<DayOfWeek> recommendationDays = findRecommendationDays(teamId);
+        long cumulativeSolveCount = articleLowService.countByMemberId(member.getId());
+
+        return TeamDashboardResponse.of(teamMember, joinDate, recommendationDays, solveCountsByDate, today, lookbackFloor, cumulativeSolveCount);
+    }
+
+    private Map<LocalDate, Long> countSolvesByDate(Long memberId, Long teamId, LocalDate from, LocalDate to) {
+        return articleLowService
+                .findCreatedDatesByMemberAndTeamInRange(memberId, teamId, from.atStartOfDay(), to.plusDays(1).atStartOfDay())
+                .stream()
+                .collect(Collectors.groupingBy(this::toKstDate, Collectors.counting()));
+    }
+
+    private LocalDate laterOf(LocalDate a, LocalDate b) {
+        return a.isAfter(b) ? a : b;
+    }
+
+    private Set<DayOfWeek> findRecommendationDays(Long teamId) {
+        return teamRecommendationRepository.findByTeamId(teamId)
+                .map(TeamRecommendation::getTeamRecommendationDays)
+                .map(days -> days.stream()
+                        .map(TeamRecommendationDay::getDayOfWeek)
+                        .collect(Collectors.toCollection(() -> EnumSet.noneOf(DayOfWeek.class))))
+                .orElseGet(() -> EnumSet.noneOf(DayOfWeek.class));
+    }
+
+    private LocalDate toKstDate(LocalDateTime dateTime) {
+        return dateTime.atZone(ZoneId.systemDefault()).withZoneSameInstant(KST).toLocalDate();
     }
 }

--- a/src/main/java/site/codemonster/comon/domain/auth/dto/request/MemberProfileCreateRequest.java
+++ b/src/main/java/site/codemonster/comon/domain/auth/dto/request/MemberProfileCreateRequest.java
@@ -1,11 +1,13 @@
 package site.codemonster.comon.domain.auth.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record MemberProfileCreateRequest(
         @NotNull
         String memberName,
         @NotNull
+        @Size(max = 40, message = "소개는 최대 40자까지 입력할 수 있습니다.")
         String memberExplain,
         String imageUrl
 ) {

--- a/src/main/java/site/codemonster/comon/domain/auth/dto/request/MemberProfileUpdateRequest.java
+++ b/src/main/java/site/codemonster/comon/domain/auth/dto/request/MemberProfileUpdateRequest.java
@@ -1,8 +1,10 @@
 package site.codemonster.comon.domain.auth.dto.request;
 
+import jakarta.validation.constraints.Size;
 
 public record MemberProfileUpdateRequest(
         String memberName,
+        @Size(max = 40, message = "소개는 최대 40자까지 입력할 수 있습니다.")
         String memberExplain,
         String imageUrl
 ) {

--- a/src/main/java/site/codemonster/comon/domain/recommendation/service/TeamRecommendationLowService.java
+++ b/src/main/java/site/codemonster/comon/domain/recommendation/service/TeamRecommendationLowService.java
@@ -26,6 +26,11 @@ public class TeamRecommendationLowService {
                 .orElseThrow(TeamRecommendationNotFoundException::new);
     }
 
+    @Transactional(readOnly = true)
+    public Optional<TeamRecommendation> findByTeamId(Long teamId) {
+        return teamRecommendationRepository.findByTeamId(teamId);
+    }
+
     public boolean isExistByTeam(Team team) {
         return teamRecommendationRepository.existsByTeam(team);
     }

--- a/src/main/java/site/codemonster/comon/domain/team/controller/TeamController.java
+++ b/src/main/java/site/codemonster/comon/domain/team/controller/TeamController.java
@@ -169,6 +169,18 @@ public class TeamController {
                 .body(ApiResponse.successResponseWithData(subjectArticlesUsingCalender));
     }
 
+    @GetMapping("/{teamId}/dashboard")
+    public ResponseEntity<ApiResponse<TeamDashboardResponse>> getDashboard(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long teamId
+    ) {
+        TeamDashboardResponse dashboard = articleService.getDashboard(member, teamId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponseWithData(dashboard));
+    }
+
     @DeleteMapping("/{teamId}/members/me")
     public ResponseEntity<ApiResponse<?>> removeMemberFromTeam(
             @AuthenticationPrincipal Member member,

--- a/src/main/java/site/codemonster/comon/domain/team/dto/response/TeamDashboardResponse.java
+++ b/src/main/java/site/codemonster/comon/domain/team/dto/response/TeamDashboardResponse.java
@@ -1,0 +1,92 @@
+package site.codemonster.comon.domain.team.dto.response;
+
+import site.codemonster.comon.domain.auth.entity.Member;
+import site.codemonster.comon.domain.team.entity.Team;
+import site.codemonster.comon.domain.teamMember.entity.TeamMember;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public record TeamDashboardResponse(
+        String teamName,
+        int nDays,
+        LocalDate joinedAt,
+        String imageUrl,
+        String memberName,
+        String description,
+        int weeklySolvedDays,
+        long consecutiveSolveCount,
+        long cumulativeSolveCount,
+        List<WeeklyGrassItem> weeklyGrass
+) {
+    public static TeamDashboardResponse of(
+            TeamMember teamMember,
+            LocalDate joinedAt,
+            Set<DayOfWeek> recommendationDays,
+            Map<LocalDate, Long> solveCountsByDate,
+            LocalDate today,
+            LocalDate lookbackFloor,
+            long cumulativeSolveCount
+    ) {
+        Member member = teamMember.getMember();
+        Team team = teamMember.getTeam();
+        LocalDate weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
+        return new TeamDashboardResponse(
+                team.getTeamName(),
+                recommendationDays.size(),
+                joinedAt,
+                member.getImageUrl(),
+                member.getMemberName(),
+                member.getDescription(),
+                countSolvedDays(solveCountsByDate, weekStart, today),
+                calculateStreak(solveCountsByDate, recommendationDays, today, lookbackFloor),
+                cumulativeSolveCount,
+                buildWeeklyGrass(solveCountsByDate, weekStart, today)
+        );
+    }
+
+    private static int countSolvedDays(Map<LocalDate, Long> solveCountsByDate, LocalDate weekStart, LocalDate today) {
+        int days = 0;
+        for (LocalDate date = weekStart; !date.isAfter(today); date = date.plusDays(1)) {
+            if (solveCountsByDate.getOrDefault(date, 0L) > 0L) {
+                days++;
+            }
+        }
+        return days;
+    }
+
+    private static long calculateStreak(Map<LocalDate, Long> solveCountsByDate, Set<DayOfWeek> recommendationDays, LocalDate today, LocalDate lookbackFloor) {
+        LocalDate streakStart = lookbackFloor;
+        for (LocalDate date = today; !date.isBefore(lookbackFloor); date = date.minusDays(1)) {
+            boolean missedRecommendedDay = date.isBefore(today)
+                    && recommendationDays.contains(date.getDayOfWeek())
+                    && solveCountsByDate.getOrDefault(date, 0L) == 0L;
+            if (missedRecommendedDay) {
+                streakStart = date.plusDays(1);
+                break;
+            }
+        }
+
+        long total = 0L;
+        for (LocalDate date = streakStart; !date.isAfter(today); date = date.plusDays(1)) {
+            total += solveCountsByDate.getOrDefault(date, 0L);
+        }
+        return total;
+    }
+
+    private static List<WeeklyGrassItem> buildWeeklyGrass(Map<LocalDate, Long> solveCountsByDate, LocalDate weekStart, LocalDate today) {
+        List<WeeklyGrassItem> grass = new ArrayList<>(7);
+        for (int i = 0; i < 7; i++) {
+            LocalDate date = weekStart.plusDays(i);
+            long count = date.isAfter(today) ? 0L : solveCountsByDate.getOrDefault(date, 0L);
+            grass.add(new WeeklyGrassItem(date.getDayOfWeek(), count));
+        }
+        return grass;
+    }
+}

--- a/src/main/java/site/codemonster/comon/domain/team/dto/response/WeeklyGrassItem.java
+++ b/src/main/java/site/codemonster/comon/domain/team/dto/response/WeeklyGrassItem.java
@@ -1,0 +1,9 @@
+package site.codemonster.comon.domain.team.dto.response;
+
+import java.time.DayOfWeek;
+
+public record WeeklyGrassItem(
+        DayOfWeek dayOfWeek,
+        long count
+) {
+}


### PR DESCRIPTION
## 🔥 관련 이슈

- close: #70

---

## 📝 작업 상세 설명

팀 내 페이지를 팀 중심에서 **개인 맞춤(습관화/동기부여)** 으로 개편하는 PRD의 **Phase 1(개인화)** 백엔드를 구현했습니다.

특정 팀 안에서 멤버 개인의 현황을 한 번에 내려주는 **대시보드 조회 API** 를 추가했습니다. 개인화 영역이 한 화면에서 렌더되므로 perf_001~008 데이터를 단일 응답으로 제공합니다.

### 엔드포인트
`GET /api/v1/teams/{teamId}/dashboard` (인증 필요)

### 응답 필드 (perf 매핑)
- `teamName` / `nDays` : 팀명 + N데이즈(2/4/6) — perf_001 (※ "코몬 N데이즈" 문자열 조합은 프론트)
- `joinedAt` : 팀 합류일("since") — perf_001
- `imageUrl` : 프로필 이미지 — perf_002
- `memberName` : 닉네임 — perf_003
- `description` : 소개(최대 40자) — perf_004
- `weeklySolvedDays` / `nDays` : 이번주 출석일수 A / N(B) — perf_005 (A>B 허용)
- `consecutiveSolveCount` : 연속 풀이 수 — perf_006
- `cumulativeSolveCount` : 누적 풀이 수(전체 팀) — perf_007
- `weeklyGrass[7]` : 월~일 요일별 풀이수(원시값) — perf_008

### 집계 규칙
- **1풀이 = 멤버 본인이 작성한 글(Article), `createdDate` 기준** (풀이글/일반글 구분 없음 — 자유게시판 부재 확인, 추천글은 systemAdmin 작성이라 자동 제외)
- 타임존 **Asia/Seoul**, 주 = **월~일**
- 연속 풀이(perf_006): 팀 추천요일(`TeamRecommendationDay`)에 0풀이로 경과하면 0 리셋, 비추천요일/오늘(미경과)은 유지. 역추적 상한 90일 또는 합류일
- 누적(perf_007): 전체 팀 평생 누적
- N(2/4/6) = 팀 추천요일 개수에서 도출 (스키마 변경 없음)

### 변경 범위
- 신규 엔드포인트 1개 (기존 `/team-page` 캘린더 API는 그대로 유지)
- **DB 스키마 변경 없음**
- 회원 소개 최대 40자 검증 추가 (perf_004)
- 기존 `TeamController` / `ArticleService` 에 통합 (새 컨트롤러·서비스 없이), 순수 계산은 `TeamDashboardResponse.of(...)` 정적 팩토리로 분리

프론트에서는 이 API로 Phase 1 개인화 영역(프로필 / 주간 출석 / 연속·누적 / 잔디)을 구성하면 됩니다. 잔디 색상(2/4/6days 칸 강조), 프로필 크롭(±77.5px), "코몬 N데이즈" 문자열 조합은 프론트에서 처리합니다.
