### PR TITLE
feat(team): 팀+날짜 추천 문제 조회 API (Phase 2 주간화)

### DIFF
--- a/src/main/java/site/codemonster/comon/domain/recommendation/dto/response/RecommendationProblemResponse.java
+++ b/src/main/java/site/codemonster/comon/domain/recommendation/dto/response/RecommendationProblemResponse.java
@@ -1,0 +1,21 @@
+package site.codemonster.comon.domain.recommendation.dto.response;
+
+import site.codemonster.comon.domain.problem.entity.Problem;
+import site.codemonster.comon.domain.problem.entity.ProblemStep;
+import site.codemonster.comon.domain.problem.enums.Platform;
+
+public record RecommendationProblemResponse(
+        ProblemStep step,
+        Platform platform,
+        String title,
+        String url
+) {
+    public static RecommendationProblemResponse from(Problem problem) {
+        return new RecommendationProblemResponse(
+                problem.getProblemStep(),
+                problem.getPlatform(),
+                problem.getTitle(),
+                problem.getUrl()
+        );
+    }
+}

--- a/src/main/java/site/codemonster/comon/domain/recommendation/repository/RecommendationHistoryRepository.java
+++ b/src/main/java/site/codemonster/comon/domain/recommendation/repository/RecommendationHistoryRepository.java
@@ -40,4 +40,11 @@ public interface RecommendationHistoryRepository extends JpaRepository<Recommend
 
     @Query("select rh from RecommendationHistory rh where rh.team.teamId = :teamId")
     List<RecommendationHistory> findByTeamId(Long teamId);
+
+    @Query("select rh from RecommendationHistory rh " +
+            "join fetch rh.problem p " +
+            "where rh.team.teamId = :teamId and rh.recommendedAt = :date " +
+            "order by p.problemStep asc")
+    List<RecommendationHistory> findByTeamIdAndRecommendedAtOrderByStep(
+            @Param("teamId") Long teamId, @Param("date") LocalDate date);
 }

--- a/src/main/java/site/codemonster/comon/domain/recommendation/service/RecommendationHistoryLowService.java
+++ b/src/main/java/site/codemonster/comon/domain/recommendation/service/RecommendationHistoryLowService.java
@@ -3,6 +3,7 @@ package site.codemonster.comon.domain.recommendation.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.codemonster.comon.domain.recommendation.dto.response.RecommendationProblemResponse;
 import site.codemonster.comon.domain.recommendation.entity.RecommendationHistory;
 import site.codemonster.comon.domain.recommendation.repository.RecommendationHistoryRepository;
 import site.codemonster.comon.domain.team.entity.Team;
@@ -25,6 +26,14 @@ public class RecommendationHistoryLowService {
 
     public List<RecommendationHistory> findByTeamId(Long teamId) {
         return recommendationHistoryRepository.findByTeamId(teamId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<RecommendationProblemResponse> getTeamRecommendations(Long teamId, LocalDate date) {
+        return recommendationHistoryRepository.findByTeamIdAndRecommendedAtOrderByStep(teamId, date)
+                .stream()
+                .map(rh -> RecommendationProblemResponse.from(rh.getProblem()))
+                .toList();
     }
 
     public void saveAll(List<RecommendationHistory> recommendationHistorys) {

--- a/src/main/java/site/codemonster/comon/domain/team/controller/TeamController.java
+++ b/src/main/java/site/codemonster/comon/domain/team/controller/TeamController.java
@@ -4,6 +4,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import site.codemonster.comon.domain.article.dto.request.CalenderSubjectRequest;
 import site.codemonster.comon.domain.article.service.ArticleService;
 import site.codemonster.comon.domain.auth.entity.Member;
+import site.codemonster.comon.domain.recommendation.dto.response.RecommendationProblemResponse;
+import site.codemonster.comon.domain.recommendation.service.RecommendationHistoryLowService;
 import site.codemonster.comon.domain.team.dto.request.*;
 import site.codemonster.comon.domain.team.dto.response.*;
 import site.codemonster.comon.domain.team.entity.Team;
@@ -17,11 +19,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,6 +40,7 @@ public class TeamController {
     private final TeamService teamService;
     private final TeamMemberService teamMemberService;
     private final ArticleService articleService;
+    private final RecommendationHistoryLowService recommendationHistoryLowService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<TeamCreateResponse>> createTeam(
@@ -179,6 +184,21 @@ public class TeamController {
         return ResponseEntity.status(HttpStatus.OK)
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(ApiResponse.successResponseWithData(dashboard));
+    }
+
+    @GetMapping("/{teamId}/recommendations")
+    public ResponseEntity<ApiResponse<List<RecommendationProblemResponse>>> getRecommendations(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long teamId,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        teamMemberService.validateTeamMember(teamId, member);
+        List<RecommendationProblemResponse> recommendations =
+                recommendationHistoryLowService.getTeamRecommendations(teamId, date);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponseWithData(recommendations));
     }
 
     @DeleteMapping("/{teamId}/members/me")

--- a/src/main/java/site/codemonster/comon/domain/teamMember/service/TeamMemberService.java
+++ b/src/main/java/site/codemonster/comon/domain/teamMember/service/TeamMemberService.java
@@ -31,6 +31,11 @@ public class TeamMemberService {
     private final TeamMemberLowService teamMemberLowService;
 
 
+    @Transactional(readOnly = true)
+    public void validateTeamMember(Long teamId, Member member){
+        teamMemberLowService.validateTeamMember(teamId, member);
+    }
+
     public void removeTeamMember(Member member, Long teamId){
         if(!teamMemberLowService.existsByTeamIdAndMemberId(teamId, member)){
             throw new TeamMemberInvalidException();

--- a/src/test/java/site/codemonster/comon/domain/team/controller/TeamControllerTest.java
+++ b/src/test/java/site/codemonster/comon/domain/team/controller/TeamControllerTest.java
@@ -15,20 +15,33 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import site.codemonster.comon.domain.auth.entity.Member;
 import site.codemonster.comon.domain.auth.repository.MemberRepository;
+import site.codemonster.comon.domain.problem.entity.Problem;
+import site.codemonster.comon.domain.problem.entity.ProblemStep;
+import site.codemonster.comon.domain.problem.enums.Platform;
+import site.codemonster.comon.domain.problem.repository.ProblemRepository;
+import site.codemonster.comon.domain.recommendation.entity.RecommendationHistory;
+import site.codemonster.comon.domain.recommendation.repository.RecommendationHistoryRepository;
 import site.codemonster.comon.domain.team.dto.request.TeamCreateRequest;
 import site.codemonster.comon.domain.team.dto.response.TeamCreateResponse;
+import site.codemonster.comon.domain.team.entity.Team;
 import site.codemonster.comon.domain.team.enums.Topic;
+import site.codemonster.comon.domain.team.repository.TeamRepository;
+import site.codemonster.comon.domain.teamMember.repository.TeamMemberRepository;
 import site.codemonster.comon.domain.util.TestSecurityContextInjector;
 import site.codemonster.comon.domain.util.TestUtil;
 import site.codemonster.comon.global.error.dto.response.ApiResponse;
 import site.codemonster.comon.global.error.response.ErrorValidationResult;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.Map;
 
 import static org.assertj.core.api.SoftAssertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.securityContext;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @AutoConfigureMockMvc
@@ -44,6 +57,18 @@ class TeamControllerTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
+
+    @Autowired
+    private ProblemRepository problemRepository;
+
+    @Autowired
+    private RecommendationHistoryRepository recommendationHistoryRepository;
 
 
     @ParameterizedTest
@@ -108,6 +133,64 @@ class TeamControllerTest {
             softly.assertThat(apiResponse.getCode()).isEqualTo(ErrorValidationResult.ERROR_STATUS_CODE);
             softly.assertThat(apiResponse.getMessage()).isEqualTo("팀 인원은 최소 1명 이상이어야합니다.");
         });
+    }
+
+    @Test
+    @DisplayName("추천 문제 조회 성공 - 멤버가 팀+날짜로 STEP 오름차순 조회")
+    void getRecommendationsSuccess() throws Exception {
+
+        Member member = memberRepository.save(TestUtil.createMember());
+        Team team = teamRepository.save(TestUtil.createTeam());
+        teamMemberRepository.save(TestUtil.createTeamMember(team, member));
+        TestSecurityContextInjector.inject(member);
+
+        LocalDate date = LocalDate.of(2026, 5, 4);
+        Problem step1 = problemRepository.save(new Problem(Platform.BAEKJOON, "1001", "STEP1 문제", ProblemStep.STEP1, "https://step1"));
+        Problem step2 = problemRepository.save(new Problem(Platform.BAEKJOON, "1002", "STEP2 문제", ProblemStep.STEP2, "https://step2"));
+        // 저장 순서를 STEP2 → STEP1 로 섞어 정렬 검증
+        recommendationHistoryRepository.save(new RecommendationHistory(team, step2, date));
+        recommendationHistoryRepository.save(new RecommendationHistory(team, step1, date));
+
+        mockMvc.perform(get("/api/v1/teams/{teamId}/recommendations", team.getTeamId())
+                        .param("date", "2026-05-04")
+                        .with(securityContext(SecurityContextHolder.getContext())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].step").value("STEP1"))
+                .andExpect(jsonPath("$.data[0].title").value("STEP1 문제"))
+                .andExpect(jsonPath("$.data[0].url").value("https://step1"))
+                .andExpect(jsonPath("$.data[1].step").value("STEP2"));
+    }
+
+    @Test
+    @DisplayName("추천 문제 조회 - 추천이 없는 날짜는 빈 배열")
+    void getRecommendationsEmpty() throws Exception {
+
+        Member member = memberRepository.save(TestUtil.createMember());
+        Team team = teamRepository.save(TestUtil.createTeam());
+        teamMemberRepository.save(TestUtil.createTeamMember(team, member));
+        TestSecurityContextInjector.inject(member);
+
+        mockMvc.perform(get("/api/v1/teams/{teamId}/recommendations", team.getTeamId())
+                        .param("date", "1999-01-01")
+                        .with(securityContext(SecurityContextHolder.getContext())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("추천 문제 조회 실패 - 팀 비멤버는 400")
+    void getRecommendationsNotMember() throws Exception {
+
+        Member member = memberRepository.save(TestUtil.createMember());
+        Team team = teamRepository.save(TestUtil.createTeam()); // 팀에 가입시키지 않음
+        TestSecurityContextInjector.inject(member);
+
+        mockMvc.perform(get("/api/v1/teams/{teamId}/recommendations", team.getTeamId())
+                        .param("date", "2026-05-04")
+                        .with(securityContext(SecurityContextHolder.getContext())))
+                .andExpect(status().isBadRequest());
     }
 
 }


### PR DESCRIPTION
## 개요
Phase 2 주간화 FE의 추천 문제 섹션(STEP1~4)에 데이터를 공급하는 **멤버 전용 조회 엔드포인트**를 신설합니다. 기존 추천 생성/스케줄러는 변경하지 않고 조회 경로만 추가합니다.

## 변경 사항
- `GET /api/v1/teams/{teamId}/recommendations?date=YYYY-MM-DD`
  - 응답: `ApiResponse<List<RecommendationProblemResponse{step, platform, title, url}>>`
  - `problemStep` 오름차순(STEP1→STEP4), 해당 팀·날짜 추천 없으면 빈 배열
  - **멤버 전용**: `TeamMemberService.validateTeamMember`(미가입 시 `TeamMemberInvalidException`, 대시보드와 동일 정책)
- 신규 `RecommendationProblemResponse`(slim record, 내부 id 미노출)
- `RecommendationHistoryRepository.findByTeamIdAndRecommendedAtOrderByStep`(problem fetch join + STEP 정렬)
- `RecommendationHistoryLowService.getTeamRecommendations`
- 기존 `RecommendationHistory`/`Problem` 재사용 — **신규 테이블/컬럼 없음**(ddl-auto 영향 없음)

## 사이드이펙트
- 추천 생성/스케줄러(`TeamRecommendationScheduler` 등) 무변경 — 조회 경로만 추가

## 테스트
- `TeamControllerTest`: 성공(STEP 정렬)/빈 배열/비멤버 400 — 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)