### PR TITLE
feat(team): 월간 풀이 날짜 조회 API 추가 (멤버 전용)

### DIFF
--- a/src/main/java/site/codemonster/comon/domain/article/service/ArticleService.java
+++ b/src/main/java/site/codemonster/comon/domain/article/service/ArticleService.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.EnumSet;
 import java.util.List;
@@ -241,6 +242,22 @@ public class ArticleService {
         long cumulativeSolveCount = articleLowService.countByMemberId(member.getId());
 
         return TeamDashboardResponse.of(teamMember, joinDate, recommendationDays, solveCountsByDate, today, lookbackFloor, cumulativeSolveCount);
+    }
+
+    // 월간 캘린더 풀이 체크박스: 해당 월에 풀이(NORMAL+노출)를 작성한 KST 날짜 목록
+    @Transactional(readOnly = true)
+    public List<LocalDate> getSolvedDates(Member member, Long teamId, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate from = yearMonth.atDay(1);
+        LocalDate toExclusive = yearMonth.plusMonths(1).atDay(1);
+
+        return articleLowService
+                .findCreatedDatesByMemberAndTeamInRange(member.getId(), teamId, kstDayStartInSystemDefault(from), kstDayStartInSystemDefault(toExclusive))
+                .stream()
+                .map(this::toKstDate)
+                .distinct()
+                .sorted()
+                .toList();
     }
 
     private Map<LocalDate, Long> countSolvesByDate(Long memberId, Long teamId, LocalDate from, LocalDate to) {

--- a/src/main/java/site/codemonster/comon/domain/team/controller/TeamController.java
+++ b/src/main/java/site/codemonster/comon/domain/team/controller/TeamController.java
@@ -201,6 +201,21 @@ public class TeamController {
                 .body(ApiResponse.successResponseWithData(recommendations));
     }
 
+    @GetMapping("/{teamId}/solved-dates")
+    public ResponseEntity<ApiResponse<List<LocalDate>>> getSolvedDates(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long teamId,
+            @RequestParam("year") int year,
+            @RequestParam("month") int month
+    ) {
+        teamMemberService.validateTeamMember(teamId, member);
+        List<LocalDate> solvedDates = articleService.getSolvedDates(member, teamId, year, month);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(ApiResponse.successResponseWithData(solvedDates));
+    }
+
     @DeleteMapping("/{teamId}/members/me")
     public ResponseEntity<ApiResponse<?>> removeMemberFromTeam(
             @AuthenticationPrincipal Member member,

--- a/src/test/java/site/codemonster/comon/domain/team/controller/TeamControllerTest.java
+++ b/src/test/java/site/codemonster/comon/domain/team/controller/TeamControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import site.codemonster.comon.domain.article.repository.ArticleRepository;
 import site.codemonster.comon.domain.auth.entity.Member;
 import site.codemonster.comon.domain.auth.repository.MemberRepository;
 import site.codemonster.comon.domain.problem.entity.Problem;
@@ -34,6 +35,7 @@ import site.codemonster.comon.global.error.response.ErrorValidationResult;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Map;
 
 import static org.assertj.core.api.SoftAssertions.*;
@@ -69,6 +71,9 @@ class TeamControllerTest {
 
     @Autowired
     private RecommendationHistoryRepository recommendationHistoryRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
 
 
     @ParameterizedTest
@@ -189,6 +194,62 @@ class TeamControllerTest {
 
         mockMvc.perform(get("/api/v1/teams/{teamId}/recommendations", team.getTeamId())
                         .param("date", "2026-05-04")
+                        .with(securityContext(SecurityContextHolder.getContext())))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("풀이 날짜 조회 성공 - 같은 날 여러 글은 한 날짜로 중복 제거")
+    void getSolvedDatesSuccess() throws Exception {
+
+        Member member = memberRepository.save(TestUtil.createMember());
+        Team team = teamRepository.save(TestUtil.createTeam());
+        teamMemberRepository.save(TestUtil.createTeamMember(team, member));
+        TestSecurityContextInjector.inject(member);
+
+        articleRepository.save(TestUtil.createArticle(team, member));
+        articleRepository.save(TestUtil.createArticle(team, member));
+
+        LocalDate todayKst = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        mockMvc.perform(get("/api/v1/teams/{teamId}/solved-dates", team.getTeamId())
+                        .param("year", String.valueOf(todayKst.getYear()))
+                        .param("month", String.valueOf(todayKst.getMonthValue()))
+                        .with(securityContext(SecurityContextHolder.getContext())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0]").value(todayKst.toString()));
+    }
+
+    @Test
+    @DisplayName("풀이 날짜 조회 - 작성 글이 없는 달은 빈 배열")
+    void getSolvedDatesEmpty() throws Exception {
+
+        Member member = memberRepository.save(TestUtil.createMember());
+        Team team = teamRepository.save(TestUtil.createTeam());
+        teamMemberRepository.save(TestUtil.createTeamMember(team, member));
+        TestSecurityContextInjector.inject(member);
+
+        mockMvc.perform(get("/api/v1/teams/{teamId}/solved-dates", team.getTeamId())
+                        .param("year", "1999")
+                        .param("month", "1")
+                        .with(securityContext(SecurityContextHolder.getContext())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("풀이 날짜 조회 실패 - 팀 비멤버는 400")
+    void getSolvedDatesNotMember() throws Exception {
+
+        Member member = memberRepository.save(TestUtil.createMember());
+        Team team = teamRepository.save(TestUtil.createTeam()); // 팀에 가입시키지 않음
+        TestSecurityContextInjector.inject(member);
+
+        mockMvc.perform(get("/api/v1/teams/{teamId}/solved-dates", team.getTeamId())
+                        .param("year", "2026")
+                        .param("month", "7")
                         .with(securityContext(SecurityContextHolder.getContext())))
                 .andExpect(status().isBadRequest());
     }


### PR DESCRIPTION
## 개요
월간 캘린더 풀이 체크박스(FE)용 신규 API.

- `GET /api/v1/teams/{teamId}/solved-dates?year=YYYY&month=M`
- 팀 멤버 전용 (recommendations와 동일하게 `validateTeamMember`, 비멤버 400)
- 해당 월에 본인이 풀이(NORMAL+노출 글)를 작성한 KST 날짜 목록(`["2026-07-03", ...]`) 반환
- 기존 `findCreatedDatesByMemberAndTeamInRange` 쿼리 재사용 — 신규 테이블/컬럼 0개, 스케줄러 무변경

## 테스트
- `TeamControllerTest` 3케이스 추가 (성공+같은 날 중복 제거 / 빈 배열 / 비멤버 400)
- 전체 10케이스 통과 (BUILD SUCCESSFUL)

## 참고
FE 연동 PR: comon-fe `feat/monthly-calendar-study-ui` (별도 생성)